### PR TITLE
Reorganize and rename packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ import (
 	"os"
 	"time"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
 	"github.com/ggoodman/mcp-server-go/sessions/redishost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 )
 
 func envOr(key, def string) string {
@@ -65,20 +65,20 @@ func main() {
 	defer host.Close()
 
 	// 2) Tools (auto-derived JSON Schema; strict by default)
-	translate := mcpserver.NewTool[TranslateArgs](
+	translate := mcpservice.NewTool[TranslateArgs](
 		"translate",
 		func(ctx context.Context, _ sessions.Session, args TranslateArgs) (*mcp.CallToolResult, error) {
-			return mcpserver.TextResult("Translated to " + args.To + ": " + args.Text), nil
+			return mcpservice.TextResult("Translated to " + args.To + ": " + args.Text), nil
 		},
-		mcpserver.WithToolDescription("Translate text to a target language."),
+		mcpservice.WithToolDescription("Translate text to a target language."),
 		// mcpserver.WithToolAllowAdditionalProperties(true), // opt-in to unknown fields
 	)
-	tools := mcpserver.NewStaticTools(translate)
+	tools := mcpservice.NewStaticTools(translate)
 
 	// 3) Server capabilities
-	server := mcpserver.NewServer(
-		mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "my-mcp", Version: "1.0.0"}),
-		mcpserver.WithToolsOptions(mcpserver.WithStaticToolsContainer(tools)),
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-mcp", Version: "1.0.0"}),
+		mcpservice.WithToolsOptions(mcpservice.WithStaticToolsContainer(tools)),
 	)
 
 	// 4) Drop-in OAuth2/OIDC JWT access token auth (RFC 9068): discovery + JWKS

--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
 )
 
 // New constructs a simple server with a single "echo" tool using TypedTool.
 // It demonstrates the static tools surface in the mcpserver package.
-func New() mcpserver.ServerCapabilities {
+func New() mcpservice.ServerCapabilities {
 	echoDesc := mcp.Tool{
 		Name:        "echo",
 		Description: "Echo a message back to the caller",
@@ -27,16 +27,16 @@ func New() mcpserver.ServerCapabilities {
 		Message string `json:"message"`
 	}
 
-	tools := mcpserver.NewStaticTools(
-		mcpserver.TypedTool(echoDesc, func(ctx context.Context, _ sessions.Session, a EchoArgs) (*mcp.CallToolResult, error) {
-			return mcpserver.TextResult("you said: " + a.Message), nil
+	tools := mcpservice.NewStaticTools(
+		mcpservice.TypedTool(echoDesc, func(ctx context.Context, _ sessions.Session, a EchoArgs) (*mcp.CallToolResult, error) {
+			return mcpservice.TextResult("you said: " + a.Message), nil
 		}),
 	)
 
-	return mcpserver.NewServer(
-		mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "examples-echo", Version: "0.1.0"}),
-		mcpserver.WithToolsOptions(
-			mcpserver.WithStaticToolsContainer(tools),
+	return mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "examples-echo", Version: "0.1.0"}),
+		mcpservice.WithToolsOptions(
+			mcpservice.WithStaticToolsContainer(tools),
 		),
 	)
 }

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"time"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
 	"github.com/ggoodman/mcp-server-go/sessions/redishost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 )
 
 func envOr(key, def string) string {
@@ -48,20 +48,20 @@ func main() {
 	defer host.Close()
 
 	// 2) Tools (auto-derived JSON Schema; strict by default)
-	translate := mcpserver.NewTool[TranslateArgs](
+	translate := mcpservice.NewTool[TranslateArgs](
 		"translate",
 		func(ctx context.Context, _ sessions.Session, args TranslateArgs) (*mcp.CallToolResult, error) {
-			return mcpserver.TextResult("Translated to " + args.To + ": " + args.Text), nil
+			return mcpservice.TextResult("Translated to " + args.To + ": " + args.Text), nil
 		},
-		mcpserver.WithToolDescription("Translate text to a target language."),
+		mcpservice.WithToolDescription("Translate text to a target language."),
 		// mcpserver.WithToolAllowAdditionalProperties(true), // opt-in to unknown fields
 	)
-	tools := mcpserver.NewStaticTools(translate)
+	tools := mcpservice.NewStaticTools(translate)
 
 	// 3) Server capabilities
-	server := mcpserver.NewServer(
-		mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "my-mcp", Version: "1.0.0"}),
-		mcpserver.WithToolsOptions(mcpserver.WithStaticToolsContainer(tools)),
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-mcp", Version: "1.0.0"}),
+		mcpservice.WithToolsOptions(mcpservice.WithStaticToolsContainer(tools)),
 	)
 
 	// 4) Drop-in OAuth2/OIDC JWT access token auth (RFC 9068): discovery + JWKS

--- a/examples/resources_fs/server.go
+++ b/examples/resources_fs/server.go
@@ -2,21 +2,21 @@ package resources_fs
 
 import (
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 )
 
 // New constructs a server that exposes a directory of the local filesystem as
 // MCP resources. It demonstrates the dynamic resources capability using the
 // FSResources implementation.
-func New(root string) mcpserver.ServerCapabilities {
-	fsCap := mcpserver.NewFSResources(
-		mcpserver.WithOSDir(root),
-		mcpserver.WithBaseURI("fs://example"),
-		mcpserver.WithFSPageSize(100),
+func New(root string) mcpservice.ServerCapabilities {
+	fsCap := mcpservice.NewFSResources(
+		mcpservice.WithOSDir(root),
+		mcpservice.WithBaseURI("fs://example"),
+		mcpservice.WithFSPageSize(100),
 	)
 
-	return mcpserver.NewServer(
-		mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "examples-resources-fs", Version: "0.1.0"}),
-		mcpserver.WithResourcesCapability(fsCap),
+	return mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "examples-resources-fs", Version: "0.1.0"}),
+		mcpservice.WithResourcesCapability(fsCap),
 	)
 }

--- a/examples/resources_per_session/server.go
+++ b/examples/resources_per_session/server.go
@@ -5,28 +5,28 @@ import (
 	"fmt"
 
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
 )
 
 // New constructs a server whose resources vary per session/user.
 // Each user sees a single profile resource at res://user/<userID>/profile.
-func New() mcpserver.ServerCapabilities {
-	resourcesProvider := func(ctx context.Context, s sessions.Session) (mcpserver.ResourcesCapability, bool, error) {
-		cap := mcpserver.NewResourcesCapability(
-			mcpserver.WithListResources(func(ctx context.Context, _ sessions.Session, _ *string) (mcpserver.Page[mcp.Resource], error) {
+func New() mcpservice.ServerCapabilities {
+	resourcesProvider := func(ctx context.Context, s sessions.Session) (mcpservice.ResourcesCapability, bool, error) {
+		cap := mcpservice.NewResourcesCapability(
+			mcpservice.WithListResources(func(ctx context.Context, _ sessions.Session, _ *string) (mcpservice.Page[mcp.Resource], error) {
 				uri := fmt.Sprintf("res://user/%s/profile", s.UserID())
-				return mcpserver.NewPage([]mcp.Resource{{URI: uri, Name: "profile", MimeType: "text/plain"}}), nil
+				return mcpservice.NewPage([]mcp.Resource{{URI: uri, Name: "profile", MimeType: "text/plain"}}), nil
 			}),
-			mcpserver.WithReadResource(func(ctx context.Context, _ sessions.Session, uri string) ([]mcp.ResourceContents, error) {
+			mcpservice.WithReadResource(func(ctx context.Context, _ sessions.Session, uri string) ([]mcp.ResourceContents, error) {
 				return []mcp.ResourceContents{{URI: uri, MimeType: "text/plain", Text: "hello, " + s.UserID()}}, nil
 			}),
 		)
 		return cap, true, nil
 	}
 
-	return mcpserver.NewServer(
-		mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "examples-resources-per-session", Version: "0.1.0"}),
-		mcpserver.WithResourcesProvider(resourcesProvider),
+	return mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "examples-resources-per-session", Version: "0.1.0"}),
+		mcpservice.WithResourcesProvider(resourcesProvider),
 	)
 }

--- a/examples/resources_static/server.go
+++ b/examples/resources_static/server.go
@@ -2,12 +2,12 @@ package resources_static
 
 import (
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 )
 
 // New constructs a server with a static resources capability: two small text resources
 // and their contents. Useful for listing and reading examples.
-func New() mcpserver.ServerCapabilities {
+func New() mcpservice.ServerCapabilities {
 	res := []mcp.Resource{
 		{URI: "res://hello.txt", Name: "hello.txt", MimeType: "text/plain"},
 		{URI: "res://readme.md", Name: "readme.md", MimeType: "text/markdown"},
@@ -17,12 +17,12 @@ func New() mcpserver.ServerCapabilities {
 		"res://readme.md": {{URI: "res://readme.md", MimeType: "text/markdown", Text: "# Readme\nThis is a test."}},
 	}
 
-	static := mcpserver.NewStaticResources(res, nil, contents)
+	static := mcpservice.NewStaticResources(res, nil, contents)
 
-	return mcpserver.NewServer(
-		mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "examples-resources-static", Version: "0.1.0"}),
-		mcpserver.WithResourcesOptions(
-			mcpserver.WithStaticResourceContainer(static),
+	return mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "examples-resources-static", Version: "0.1.0"}),
+		mcpservice.WithResourcesOptions(
+			mcpservice.WithStaticResourceContainer(static),
 		),
 	)
 }

--- a/mcpservice/capabilities.go
+++ b/mcpservice/capabilities.go
@@ -21,7 +21,7 @@
 //   - Pagination uses the Page[T] type in this package; a nil cursor requests
 //     the first page. Implementations SHOULD populate NextCursor when more data
 //     is available.
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/change_notifier.go
+++ b/mcpservice/change_notifier.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/doc.go
+++ b/mcpservice/doc.go
@@ -58,4 +58,4 @@
 //	)
 //
 // See server.go and capability files for full API details.
-package mcpserver
+package mcpservice

--- a/mcpservice/fs_resources.go
+++ b/mcpservice/fs_resources.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/fs_resources_test.go
+++ b/mcpservice/fs_resources_test.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/pagination.go
+++ b/mcpservice/pagination.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 // Page represents a single page of results with an optional cursor for fetching
 // the next page. It is a generic helper intended for server capability methods

--- a/mcpservice/resources.go
+++ b/mcpservice/resources.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/server.go
+++ b/mcpservice/server.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/static_resources.go
+++ b/mcpservice/static_resources.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/mcpservice/static_tools.go
+++ b/mcpservice/static_tools.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"bytes"

--- a/mcpservice/tools.go
+++ b/mcpservice/tools.go
@@ -1,4 +1,4 @@
-package mcpserver
+package mcpservice
 
 import (
 	"context"

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ggoodman/mcp-server-go/internal/sessioncore"
 	"github.com/ggoodman/mcp-server-go/internal/wellknown"
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
 )
 
@@ -117,7 +117,7 @@ type StreamingHTTPHandler struct {
 	authServerMetadataURL *url.URL
 
 	auth        auth.Authenticator
-	mcp         mcpserver.ServerCapabilities
+	mcp         mcpservice.ServerCapabilities
 	sessions    *sessioncore.SessionManager
 	sessionHost sessions.SessionHost
 
@@ -202,7 +202,7 @@ func New(
 	ctx context.Context,
 	publicEndpoint string,
 	host sessions.SessionHost,
-	server mcpserver.ServerCapabilities,
+	server mcpservice.ServerCapabilities,
 	authenticator auth.Authenticator,
 	opts ...Option,
 ) (*StreamingHTTPHandler, error) {

--- a/tests/examples_e2e_test.go
+++ b/tests/examples_e2e_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/examples/echo"
 	"github.com/ggoodman/mcp-server-go/sessions/memoryhost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/tests/resources_e2e_test.go
+++ b/tests/resources_e2e_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/examples/resources_static"
 	"github.com/ggoodman/mcp-server-go/sessions/memoryhost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/tests/resources_listchanged_e2e_test.go
+++ b/tests/resources_listchanged_e2e_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions/memoryhost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 )
 
 type noAuthLC struct{}
@@ -33,14 +33,14 @@ func TestResources_ListChanged_E2E(t *testing.T) {
 	// emits list-changed notifications on mutations (add/remove/replace), and
 	// the resources capability advertises listChanged support when a static
 	// container is used—no explicit ChangeNotifier wiring required.
-	static := mcpserver.NewStaticResources(
+	static := mcpservice.NewStaticResources(
 		[]mcp.Resource{{URI: "res://a", Name: "a"}},
 		nil,
 		map[string][]mcp.ResourceContents{"res://a": {{URI: "res://a", Text: "A"}}},
 	)
-	srvCaps := mcpserver.NewServer(
-		mcpserver.WithResourcesOptions(
-			mcpserver.WithStaticResourceContainer(static),
+	srvCaps := mcpservice.NewServer(
+		mcpservice.WithResourcesOptions(
+			mcpservice.WithStaticResourceContainer(static),
 		),
 	)
 

--- a/tests/session_delete_e2e_test.go
+++ b/tests/session_delete_e2e_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions/memoryhost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 )
 
 type noAuthDel struct{}
@@ -29,7 +29,7 @@ func TestDeleteSession_ClosesStreamsAndRevokes(t *testing.T) {
 
 	mh := memoryhost.New()
 	// Minimal server capabilities
-	srvCaps := mcpserver.NewServer()
+	srvCaps := mcpservice.NewServer()
 
 	var handler http.Handler
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handler.ServeHTTP(w, r) }))

--- a/tests/session_lifecycle_e2e_test.go
+++ b/tests/session_lifecycle_e2e_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/mcp"
-	"github.com/ggoodman/mcp-server-go/mcpserver"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
 	"github.com/ggoodman/mcp-server-go/sessions/memoryhost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 )
 
 type noAuthSL struct{}
@@ -33,7 +33,7 @@ func TestSessionLifecycle_GetStreamBoundToRequest(t *testing.T) {
 	mh := memoryhost.New()
 
 	// Minimal server with no special capabilities required for lifecycle check
-	srvCaps := mcpserver.NewServer()
+	srvCaps := mcpservice.NewServer()
 
 	var handler http.Handler
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handler.ServeHTTP(w, r) }))
@@ -125,11 +125,11 @@ func TestSessionLifecycle_PostBoundToRequest_WriteFallback(t *testing.T) {
 	ctx := t.Context()
 
 	mh := memoryhost.New()
-	srvCaps := mcpserver.NewServer(
+	srvCaps := mcpservice.NewServer(
 		// Provide a trivial resources capability so we can make a small request
-		mcpserver.WithResourcesOptions(
-			mcpserver.WithListResources(func(ctx context.Context, s sessions.Session, c *string) (mcpserver.Page[mcp.Resource], error) {
-				return mcpserver.NewPage([]mcp.Resource{}), nil
+		mcpservice.WithResourcesOptions(
+			mcpservice.WithListResources(func(ctx context.Context, s sessions.Session, c *string) (mcpservice.Page[mcp.Resource], error) {
+				return mcpservice.NewPage([]mcp.Resource{}), nil
 			}),
 		),
 	)

--- a/tests/workspace_fs_e2e_test.go
+++ b/tests/workspace_fs_e2e_test.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	streaminghttp "github.com/ggoodman/mcp-server-go"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/examples/workspace_fs"
 	"github.com/ggoodman/mcp-server-go/sessions/memoryhost"
+	"github.com/ggoodman/mcp-server-go/streaminghttp"
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 


### PR DESCRIPTION
Refactor package structure by renaming `mcpserver` to `mcpservice` and reorganizing imports for clarity and consistency.