### PR TITLE
Add stdio transport for MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+## Unreleased
+
+### Added: stdio transport (experimental)
+
+Introduce a new `stdio` transport package that enables running an MCP server over standard input/output. This is ideal for embedding servers as subprocesses or for local development when HTTP transports are unnecessary.
+
+Highlights
+
+- Single-connection transport reading JSON-RPC messages from `stdin` and writing responses to `stdout`.
+- Works with existing `mcpservice.ServerCapabilities` – no behavioral changes to your server code.
+- Defaults:
+  - Input: `os.Stdin`
+  - Output: `os.Stdout`
+  - User identity: current OS user (username or UID)
+- Options pattern allows overrides: custom `io.Reader`/`io.Writer`, logger, and user provider.
+
+Usage
+
+```go
+srv := mcpservice.NewServer(
+    mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-stdio-server", Version: "0.1.0"}),
+    // ... add tools/resources/prompts
+)
+
+h := stdio.NewHandler(srv)
+if err := h.Serve(context.Background()); err != nil {
+    log.Fatal(err)
+}
+```
+
+Customizing IO and Identity
+
+```go
+bufIn := bytes.NewBuffer(nil)
+bufOut := &bytes.Buffer{}
+h := stdio.NewHandler(srv,
+    stdio.WithIO(bufIn, bufOut),
+    stdio.WithUserProvider(MyUserProvider{}),
+)
+```
+
+Notes
+
+- The `stdio` transport intentionally skips HTTP auth and session headers. It identifies the caller as the current OS user by default. If you need a different identity model (e.g., per-pipe identity), supply a custom `UserProvider`.
+- Lifecycle follows MCP basics: `initialize` -> `initialized` -> normal operation -> shutdown on EOF or context cancel.
+- The API is stable; the internal loop implementation will land in a follow-up commit and adhere to the MCP stdio framing rules.
+
+Security
+
+- Suitable for local/embedded usage. For networked scenarios or multi-tenant environments, use the `streaminghttp` transport with proper authorization and session management.

--- a/internal/outbound/dispatcher.go
+++ b/internal/outbound/dispatcher.go
@@ -1,0 +1,178 @@
+package outbound
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/mcp"
+)
+
+// Transport abstracts how requests/notifications are sent and allows transports
+// to subscribe to response rendezvous channels before sending to avoid races.
+type Transport interface {
+	// SendRequest sends the request with the pre-allocated id. Implementations
+	// may subscribe to the rendezvous topic (e.g., rv:<id>) before actually
+	// emitting the request to guarantee no response is missed.
+	SendRequest(ctx context.Context, id *jsonrpc.RequestID, req *jsonrpc.Request) error
+	// SendCancelled emits a notifications/cancelled for the given id string.
+	SendCancelled(ctx context.Context, requestID string) error
+}
+
+var (
+	// ErrDispatcherClosed indicates the dispatcher is closed.
+	ErrDispatcherClosed = errors.New("dispatcher closed")
+	// ErrRemoteCancelled indicates the peer cancelled the request.
+	ErrRemoteCancelled = errors.New("remote cancelled")
+)
+
+type pendingCall struct {
+	respCh chan *jsonrpc.Response
+	errCh  chan error
+}
+
+// Dispatcher coordinates server-initiated JSON-RPC requests with correlation,
+// cancellation, and response routing. It is transport-agnostic.
+type Dispatcher struct {
+	t Transport
+
+	mu      sync.Mutex
+	pending map[string]*pendingCall // id.String() -> call
+
+	nextID uint64
+
+	closed   atomic.Bool
+	closeErr error
+}
+
+// New constructs a Dispatcher using the provided transport.
+func New(t Transport) *Dispatcher {
+	return &Dispatcher{t: t, pending: make(map[string]*pendingCall)}
+}
+
+// Call sends a JSON-RPC request and waits for a response or context cancellation.
+func (d *Dispatcher) Call(ctx context.Context, method string, params any) (*jsonrpc.Response, error) {
+	if d.closed.Load() {
+		if d.closeErr != nil {
+			return nil, d.closeErr
+		}
+		return nil, ErrDispatcherClosed
+	}
+
+	// Allocate ID
+	idNum := atomic.AddUint64(&d.nextID, 1)
+	id := jsonrpc.NewRequestID(idNum)
+	key := id.String()
+
+	// Marshal params
+	var paramsRaw json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return nil, fmt.Errorf("marshal params: %w", err)
+		}
+		paramsRaw = b
+	}
+
+	// Register pending
+	pc := &pendingCall{respCh: make(chan *jsonrpc.Response, 1), errCh: make(chan error, 1)}
+	d.mu.Lock()
+	if d.closed.Load() {
+		d.mu.Unlock()
+		if d.closeErr != nil {
+			return nil, d.closeErr
+		}
+		return nil, ErrDispatcherClosed
+	}
+	d.pending[key] = pc
+	d.mu.Unlock()
+
+	// Send request via transport. Transport may subscribe before emit.
+	req := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: method, Params: paramsRaw, ID: id}
+	if err := d.t.SendRequest(ctx, id, req); err != nil {
+		d.mu.Lock()
+		delete(d.pending, key)
+		d.mu.Unlock()
+		return nil, err
+	}
+
+	// Await response or cancellation
+	select {
+	case resp := <-pc.respCh:
+		return resp, nil
+	case err := <-pc.errCh:
+		if err != nil {
+			return nil, err
+		}
+		return nil, ErrDispatcherClosed
+	case <-ctx.Done():
+		// Best-effort cancel message to client via transport
+		_ = d.t.SendCancelled(context.Background(), key)
+		d.mu.Lock()
+		delete(d.pending, key)
+		d.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+// OnResponse delivers an incoming response to a waiting call. Unmatched responses are ignored.
+func (d *Dispatcher) OnResponse(resp *jsonrpc.Response) {
+	if resp == nil || resp.ID == nil {
+		return
+	}
+	key := resp.ID.String()
+	d.mu.Lock()
+	pc, ok := d.pending[key]
+	if ok {
+		delete(d.pending, key)
+	}
+	d.mu.Unlock()
+	if ok {
+		pc.respCh <- resp
+	}
+}
+
+// OnNotification processes peer notifications relevant to outbound calls (cancel/progress).
+func (d *Dispatcher) OnNotification(any jsonrpc.AnyMessage) {
+	switch any.Method {
+	case string(mcp.CancelledNotificationMethod):
+		var p mcp.CancelledNotification
+		if err := json.Unmarshal(any.Params, &p); err != nil {
+			return
+		}
+		key := p.RequestID
+		d.mu.Lock()
+		pc, ok := d.pending[key]
+		if ok {
+			delete(d.pending, key)
+		}
+		d.mu.Unlock()
+		if ok {
+			pc.errCh <- ErrRemoteCancelled
+		}
+	case string(mcp.ProgressNotificationMethod):
+		// Currently ignored; kept for forward compatibility.
+		return
+	}
+}
+
+// Close cancels all pending calls with the provided error and prevents new calls.
+func (d *Dispatcher) Close(err error) {
+	if !d.closed.CompareAndSwap(false, true) {
+		return
+	}
+	if err == nil {
+		err = ErrDispatcherClosed
+	}
+	d.closeErr = err
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for key, pc := range d.pending {
+		delete(d.pending, key)
+		pc.errCh <- err
+	}
+}

--- a/stdio/doc.go
+++ b/stdio/doc.go
@@ -1,0 +1,39 @@
+// Package stdio provides a minimal MCP transport over stdin/stdout.
+//
+// Overview
+//   - Single-connection transport suitable for spawning an MCP server as a subprocess
+//   - Defaults to wiring to os.Stdin and os.Stdout
+//   - Optionally accepts custom io.Reader/io.Writer via the functional options pattern
+//   - Uses the current OS user as the authenticated principal by default
+//
+// The stdio transport is intentionally lightweight: it avoids HTTP, sessions hosts,
+// and authorization discovery/metadata. It is ideal for local development and for
+// servers embedded inside other processes that want to speak MCP over pipes.
+//
+// Example
+//
+//	package main
+//
+//	import (
+//	    "context"
+//	    "log"
+//
+//	    "github.com/ggoodman/mcp-server-go/mcp"
+//	    "github.com/ggoodman/mcp-server-go/mcpservice"
+//	    "github.com/ggoodman/mcp-server-go/stdio"
+//	)
+//
+//	func main() {
+//	    // Describe your server capabilities as usual.
+//	    server := mcpservice.NewServer(
+//	        mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-stdio-server", Version: "0.1.0"}),
+//	        // mcpservice.WithToolsOptions(...), mcpservice.WithResourcesOptions(...), etc.
+//	    )
+//
+//	    h := stdio.NewHandler(server)
+//
+//	    if err := h.Serve(context.Background()); err != nil {
+//	        log.Fatal(err)
+//	    }
+//	}
+package stdio

--- a/stdio/handler.go
+++ b/stdio/handler.go
@@ -1,0 +1,538 @@
+package stdio
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/mcp"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
+	"github.com/ggoodman/mcp-server-go/sessions"
+)
+
+// Handler is a single-connection stdio transport that reads JSON-RPC messages
+// from an io.Reader and writes responses to an io.Writer. By default, it uses
+// os.Stdin and os.Stdout. It authenticates the peer using a UserProvider, which
+// defaults to the current OS user ID.
+//
+// The handler is transport-only; it delegates all MCP semantics to the provided
+// mcpservice.ServerCapabilities.
+type Handler struct {
+	srv mcpservice.ServerCapabilities
+
+	r io.Reader
+	w io.Writer
+	l *slog.Logger
+
+	userProvider UserProvider
+}
+
+// NewHandler constructs a stdio Handler with defaults and applies options.
+func NewHandler(srv mcpservice.ServerCapabilities, opts ...Option) *Handler {
+	h := &Handler{
+		srv:          srv,
+		r:            os.Stdin,
+		w:            os.Stdout,
+		l:            slog.Default(),
+		userProvider: OSUserProvider{},
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// Serve runs the stdio event loop until EOF on the reader or the context is canceled.
+// It is safe to call at most once per Handler. Serve is responsible for:
+//   - JSON-RPC message framing (newline-delimited)
+//   - initialize/initialized lifecycle with the provided ServerCapabilities
+//   - routing requests/notifications/responses to the capabilities
+//   - writing JSON-RPC responses to the writer
+//
+// The exact wire-format and behavior mirror the MCP stdio transport described in the
+// specs; this function focuses on API shape. Implementation will be added in a
+// follow-up.
+func (h *Handler) Serve(ctx context.Context) error {
+	// IO setup
+	reader := bufio.NewReader(h.r)
+	bw := bufio.NewWriter(h.w)
+	wm := &writeMux{w: bw}
+
+	// Identify user via provider
+	uid, err := h.userProvider.CurrentUserID()
+	if err != nil {
+		return err
+	}
+
+	// Session state
+	var sess *stdioSession // established after initialize
+	initialized := false
+
+	for {
+		// Respect context
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Read next line (newline-delimited JSON per stdio transport)
+		line, rerr := reader.ReadBytes('\n')
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				// Graceful shutdown on EOF
+				_ = bw.Flush()
+				return nil
+			}
+			// Retry briefly on read timeouts
+			var ne net.Error
+			if errors.As(rerr, &ne) && ne.Timeout() {
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			return rerr
+		}
+		if len(line) == 0 || isAllWhitespace(line) {
+			continue
+		}
+
+		var any jsonrpc.AnyMessage
+		if err := json.Unmarshal(line, &any); err != nil {
+			// Malformed JSON; per JSON-RPC, we can't reliably respond. Log and continue.
+			h.l.Debug("invalid JSON-RPC", slog.String("err", err.Error()))
+			continue
+		}
+
+		if !initialized {
+			// Expect initialize request
+			req := any.AsRequest()
+			if req == nil || req.Method != string(mcp.InitializeMethod) {
+				// Protocol violation: expect initialize. Ignore until we get one.
+				h.l.Debug("expected initialize first; ignoring message", slog.String("type", any.Type()), slog.String("method", any.Method))
+				continue
+			}
+
+			var initReq mcp.InitializeRequest
+			if err := json.Unmarshal(req.Params, &initReq); err != nil {
+				// Respond with invalid params
+				resp := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid initialize params", nil)
+				if werr := wm.writeJSONRPC(resp); werr != nil {
+					return werr
+				}
+				continue
+			}
+
+			negotiated := initReq.ProtocolVersion
+			// Allow server to prefer a version.
+			bs := &bootstrapSession{userID: uid}
+			if v, ok, err := h.srv.GetPreferredProtocolVersion(ctx, bs); err == nil && ok && v != "" {
+				negotiated = v
+			}
+
+			// Construct a minimal session for capability discovery and subsequent requests.
+			sess = &stdioSession{userID: uid, proto: negotiated}
+
+			// Build initialize result by probing server capabilities.
+			serverInfo, err := h.srv.GetServerInfo(ctx, sess)
+			if err != nil {
+				resp := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "failed to get server info", nil)
+				if werr := wm.writeJSONRPC(resp); werr != nil {
+					return werr
+				}
+				continue
+			}
+
+			initRes := &mcp.InitializeResult{ProtocolVersion: negotiated, ServerInfo: serverInfo}
+
+			// Resources capability
+			if resCap, ok, err := h.srv.GetResourcesCapability(ctx, sess); err != nil {
+				resp := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "failed to get resources capability", nil)
+				if werr := wm.writeJSONRPC(resp); werr != nil {
+					return werr
+				}
+				continue
+			} else if ok && resCap != nil {
+				var listChanged, subscribe bool
+				if _, ok, err := resCap.GetListChangedCapability(ctx, sess); err == nil {
+					listChanged = ok
+				}
+				if _, ok, err := resCap.GetSubscriptionCapability(ctx, sess); err == nil {
+					subscribe = ok
+				}
+				initRes.Capabilities.Resources = &struct {
+					ListChanged bool `json:"listChanged"`
+					Subscribe   bool `json:"subscribe"`
+				}{ListChanged: listChanged, Subscribe: subscribe}
+			}
+
+			// Tools capability
+			if toolsCap, ok, err := h.srv.GetToolsCapability(ctx, sess); err != nil {
+				resp := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "failed to get tools capability", nil)
+				if werr := wm.writeJSONRPC(resp); werr != nil {
+					return werr
+				}
+				continue
+			} else if ok && toolsCap != nil {
+				var listChanged bool
+				if _, ok, err := toolsCap.GetListChangedCapability(ctx, sess); err == nil {
+					listChanged = ok
+				}
+				initRes.Capabilities.Tools = &struct {
+					ListChanged bool `json:"listChanged"`
+				}{ListChanged: listChanged}
+			}
+
+			// Prompts capability
+			if promptsCap, ok, err := h.srv.GetPromptsCapability(ctx, sess); err != nil {
+				resp := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "failed to get prompts capability", nil)
+				if werr := wm.writeJSONRPC(resp); werr != nil {
+					return werr
+				}
+				continue
+			} else if ok && promptsCap != nil {
+				var listChanged bool
+				if _, ok, err := promptsCap.GetListChangedCapability(ctx, sess); err == nil {
+					listChanged = ok
+				}
+				initRes.Capabilities.Prompts = &struct {
+					ListChanged bool `json:"listChanged"`
+				}{ListChanged: listChanged}
+			}
+
+			// Optional instructions
+			if instr, ok, err := h.srv.GetInstructions(ctx, sess); err == nil && ok {
+				initRes.Instructions = instr
+			}
+
+			// Respond
+			if resp, err := jsonrpc.NewResultResponse(req.ID, initRes); err != nil {
+				r2 := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "failed to encode initialize result", nil)
+				if werr := wm.writeJSONRPC(r2); werr != nil {
+					return werr
+				}
+			} else if werr := wm.writeJSONRPC(resp); werr != nil {
+				return werr
+			}
+
+			// After successful initialize, register listChanged callbacks where supported.
+			// Use the Serve context for automatic teardown on handler exit.
+			if resCap, ok, err := h.srv.GetResourcesCapability(ctx, sess); err == nil && ok && resCap != nil {
+				if lcap, ok, err := resCap.GetListChangedCapability(ctx, sess); err == nil && ok && lcap != nil {
+					_, _ = lcap.Register(ctx, sess, func(_ context.Context, _ sessions.Session, _ string) {
+						n := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: string(mcp.ResourcesListChangedNotificationMethod)}
+						_ = wm.writeJSONRPC(n)
+					})
+				}
+			}
+			if tcap, ok, err := h.srv.GetToolsCapability(ctx, sess); err == nil && ok && tcap != nil {
+				if lcap, ok, err := tcap.GetListChangedCapability(ctx, sess); err == nil && ok && lcap != nil {
+					_, _ = lcap.Register(ctx, sess, func(_ context.Context, _ sessions.Session) {
+						n := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: string(mcp.ToolsListChangedNotificationMethod)}
+						_ = wm.writeJSONRPC(n)
+					})
+				}
+			}
+			if pcap, ok, err := h.srv.GetPromptsCapability(ctx, sess); err == nil && ok && pcap != nil {
+				if lcap, ok, err := pcap.GetListChangedCapability(ctx, sess); err == nil && ok && lcap != nil {
+					_, _ = lcap.Register(ctx, sess, func(_ context.Context, _ sessions.Session) {
+						n := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: string(mcp.PromptsListChangedNotificationMethod)}
+						_ = wm.writeJSONRPC(n)
+					})
+				}
+			}
+
+			initialized = true
+			continue
+		}
+
+		// After initialization
+		switch any.Type() {
+		case "notification":
+			// We accept notifications like notifications/initialized, cancelled, progress, etc., and ignore by default.
+			continue
+		case "response":
+			// No server-initiated requests in stdio baseline. Ignore.
+			continue
+		case "request":
+			req := any.AsRequest()
+			if req == nil || req.ID == nil {
+				continue
+			}
+			// Dispatch
+			resp, err := h.handleRequest(ctx, sess, req)
+			if err != nil {
+				// Map internal error
+				r := jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
+				if werr := wm.writeJSONRPC(r); werr != nil {
+					return werr
+				}
+				continue
+			}
+			if resp != nil {
+				if werr := wm.writeJSONRPC(resp); werr != nil {
+					return werr
+				}
+			}
+		}
+	}
+}
+
+// handleRequest routes JSON-RPC requests to server capabilities and produces a response.
+func (h *Handler) handleRequest(ctx context.Context, session sessions.Session, req *jsonrpc.Request) (*jsonrpc.Response, error) {
+	switch req.Method {
+	case string(mcp.PingMethod):
+		return jsonrpc.NewResultResponse(req.ID, struct{}{})
+
+	case string(mcp.ToolsListMethod):
+		toolsCap, ok, err := h.srv.GetToolsCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || toolsCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "tools capability not supported", nil), nil
+		}
+		var in mcp.ListToolsRequest
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		page, err := toolsCap.ListTools(ctx, session, cursorPtr(in.Cursor))
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, &mcp.ListToolsResult{
+			Tools: page.Items,
+			PaginatedResult: mcp.PaginatedResult{
+				NextCursor: deref(page.NextCursor),
+			},
+		})
+
+	case string(mcp.ToolsCallMethod):
+		toolsCap, ok, err := h.srv.GetToolsCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || toolsCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "tools capability not supported", nil), nil
+		}
+		var in mcp.CallToolRequestReceived
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		result, err := toolsCap.CallTool(ctx, session, &in)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, result)
+
+	case string(mcp.ResourcesListMethod):
+		resCap, ok, err := h.srv.GetResourcesCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || resCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "resources capability not supported", nil), nil
+		}
+		var in mcp.ListResourcesRequest
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		page, err := resCap.ListResources(ctx, session, cursorPtr(in.Cursor))
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, &mcp.ListResourcesResult{
+			Resources:       page.Items,
+			PaginatedResult: mcp.PaginatedResult{NextCursor: deref(page.NextCursor)},
+		})
+
+	case string(mcp.ResourcesReadMethod):
+		resCap, ok, err := h.srv.GetResourcesCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || resCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "resources capability not supported", nil), nil
+		}
+		var in mcp.ReadResourceRequest
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		contents, err := resCap.ReadResource(ctx, session, in.URI)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, &mcp.ReadResourceResult{Contents: contents})
+
+	case string(mcp.ResourcesSubscribeMethod):
+		resCap, ok, err := h.srv.GetResourcesCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || resCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "resources capability not supported", nil), nil
+		}
+		subCap, ok, err := resCap.GetSubscriptionCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || subCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "resources subscriptions not supported", nil), nil
+		}
+		var in mcp.SubscribeRequest
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		if err := subCap.Subscribe(ctx, session, in.URI); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, &mcp.EmptyResult{})
+
+	case string(mcp.ResourcesUnsubscribeMethod):
+		resCap, ok, err := h.srv.GetResourcesCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || resCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "resources capability not supported", nil), nil
+		}
+		subCap, ok, err := resCap.GetSubscriptionCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || subCap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "resources subscriptions not supported", nil), nil
+		}
+		var in mcp.UnsubscribeRequest
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		if err := subCap.Unsubscribe(ctx, session, in.URI); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, &mcp.EmptyResult{})
+
+	case string(mcp.PromptsListMethod):
+		pcap, ok, err := h.srv.GetPromptsCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || pcap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "prompts capability not supported", nil), nil
+		}
+		var in mcp.ListPromptsRequest
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		page, err := pcap.ListPrompts(ctx, session, cursorPtr(in.Cursor))
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, &mcp.ListPromptsResult{
+			Prompts:         page.Items,
+			PaginatedResult: mcp.PaginatedResult{NextCursor: deref(page.NextCursor)},
+		})
+
+	case string(mcp.PromptsGetMethod):
+		pcap, ok, err := h.srv.GetPromptsCapability(ctx, session)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		if !ok || pcap == nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "prompts capability not supported", nil), nil
+		}
+		var in mcp.GetPromptRequestReceived
+		if err := json.Unmarshal(req.Params, &in); err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid parameters", nil), nil
+		}
+		result, err := pcap.GetPrompt(ctx, session, &in)
+		if err != nil {
+			return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil), nil
+		}
+		return jsonrpc.NewResultResponse(req.ID, result)
+	}
+	return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeMethodNotFound, "method not found", nil), nil
+}
+
+// stdioSession is a minimal sessions.Session implementation for stdio transport.
+type stdioSession struct {
+	userID string
+	proto  string
+}
+
+func (s *stdioSession) SessionID() string                                          { return fmt.Sprintf("%d", os.Getpid()) }
+func (s *stdioSession) UserID() string                                             { return s.userID }
+func (s *stdioSession) ProtocolVersion() string                                    { return s.proto }
+func (s *stdioSession) GetSamplingCapability() (sessions.SamplingCapability, bool) { return nil, false }
+func (s *stdioSession) GetRootsCapability() (sessions.RootsCapability, bool)       { return nil, false }
+func (s *stdioSession) GetElicitationCapability() (sessions.ElicitationCapability, bool) {
+	return nil, false
+}
+
+// bootstrapSession is used only for version preference probe during initialize.
+type bootstrapSession struct{ userID string }
+
+func (b *bootstrapSession) SessionID() string       { return "" }
+func (b *bootstrapSession) UserID() string          { return b.userID }
+func (b *bootstrapSession) ProtocolVersion() string { return "" }
+func (b *bootstrapSession) GetSamplingCapability() (sessions.SamplingCapability, bool) {
+	return nil, false
+}
+func (b *bootstrapSession) GetRootsCapability() (sessions.RootsCapability, bool) { return nil, false }
+func (b *bootstrapSession) GetElicitationCapability() (sessions.ElicitationCapability, bool) {
+	return nil, false
+}
+
+// writeMux serializes writes and ensures newline framing.
+type writeMux struct {
+	mu sync.Mutex
+	w  *bufio.Writer
+}
+
+func (w *writeMux) writeJSONRPC(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, err := w.w.Write(b); err != nil {
+		return err
+	}
+	if err := w.w.WriteByte('\n'); err != nil {
+		return err
+	}
+	return w.w.Flush()
+}
+
+func isAllWhitespace(b []byte) bool {
+	for _, c := range b {
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+			return false
+		}
+	}
+	return true
+}
+
+func cursorPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	cp := s
+	return &cp
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/stdio/handler_test.go
+++ b/stdio/handler_test.go
@@ -1,0 +1,710 @@
+package stdio
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/mcp"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
+	"github.com/ggoodman/mcp-server-go/sessions"
+)
+
+func TestInitializeAndPing(t *testing.T) {
+	t.Parallel()
+
+	// Prepare server capabilities
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-test", Version: "0.1.0"}),
+	)
+
+	// Input: initialize + ping, newline-delimited
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	}
+	pingReq := map[string]any{"jsonrpc": "2.0", "id": 2, "method": string(mcp.PingMethod)}
+
+	var in bytes.Buffer
+	mustWriteJSONL(t, &in, initReq)
+	mustWriteJSONL(t, &in, pingReq)
+
+	var out bytes.Buffer
+	h := NewHandler(server, WithIO(&in, &out))
+
+	if err := h.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	lines := splitNonEmptyLines(out.String())
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 responses, got %d: %q", len(lines), out.String())
+	}
+
+	// Validate initialize response
+	var initRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[0]), &initRes); err != nil {
+		t.Fatalf("unmarshal init response: %v", err)
+	}
+	if initRes.Error != nil {
+		t.Fatalf("init error: %+v", initRes.Error)
+	}
+	var initPayload mcp.InitializeResult
+	if err := json.Unmarshal(initRes.Result, &initPayload); err != nil {
+		t.Fatalf("unmarshal init payload: %v", err)
+	}
+	if got, want := initPayload.ProtocolVersion, "2025-06-18"; got != want {
+		t.Fatalf("protocol version: got %q want %q", got, want)
+	}
+	if initPayload.ServerInfo.Name != "stdio-test" || initPayload.ServerInfo.Version != "0.1.0" {
+		t.Fatalf("server info mismatch: %+v", initPayload.ServerInfo)
+	}
+
+	// Validate ping response
+	var pingRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[1]), &pingRes); err != nil {
+		t.Fatalf("unmarshal ping response: %v", err)
+	}
+	if pingRes.Error != nil {
+		t.Fatalf("ping error: %+v", pingRes.Error)
+	}
+}
+
+func TestToolsList(t *testing.T) {
+	t.Parallel()
+
+	// Tools capability with one tool
+	tool := mcp.Tool{
+		Name:        "echo",
+		Description: "Echo input",
+		InputSchema: mcp.ToolInputSchema{Type: "object"},
+	}
+	tools := mcpservice.NewToolsCapability(
+		mcpservice.WithListTools(func(_ context.Context, _ sessions.Session, _ *string) (mcpservice.Page[mcp.Tool], error) {
+			return mcpservice.NewPage([]mcp.Tool{tool}), nil
+		}),
+	)
+
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-tools", Version: "0.1.0"}),
+		mcpservice.WithToolsCapability(tools),
+	)
+
+	// initialize + tools/list
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	}
+	listReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  string(mcp.ToolsListMethod),
+		"params":  map[string]any{"cursor": ""},
+	}
+
+	var in bytes.Buffer
+	mustWriteJSONL(t, &in, initReq)
+	mustWriteJSONL(t, &in, listReq)
+	var out bytes.Buffer
+
+	h := NewHandler(server, WithIO(&in, &out))
+	if err := h.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	lines := splitNonEmptyLines(out.String())
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 responses, got %d: %q", len(lines), out.String())
+	}
+
+	// tools/list response
+	var toolsRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[1]), &toolsRes); err != nil {
+		t.Fatalf("unmarshal tools response: %v", err)
+	}
+	if toolsRes.Error != nil {
+		t.Fatalf("tools list error: %+v", toolsRes.Error)
+	}
+	var payload mcp.ListToolsResult
+	if err := json.Unmarshal(toolsRes.Result, &payload); err != nil {
+		t.Fatalf("unmarshal tools payload: %v", err)
+	}
+	if len(payload.Tools) != 1 || payload.Tools[0].Name != "echo" {
+		t.Fatalf("unexpected tools payload: %+v", payload)
+	}
+}
+
+func TestResourcesListAndRead(t *testing.T) {
+	t.Parallel()
+
+	res := mcp.Resource{URI: "res://hello.txt", Name: "hello.txt"}
+	contents := []mcp.ResourceContents{{URI: res.URI, Text: "hello"}}
+
+	resources := mcpservice.NewResourcesCapability(
+		mcpservice.WithListResources(func(_ context.Context, _ sessions.Session, _ *string) (mcpservice.Page[mcp.Resource], error) {
+			return mcpservice.NewPage([]mcp.Resource{res}), nil
+		}),
+		mcpservice.WithReadResource(func(_ context.Context, _ sessions.Session, uri string) ([]mcp.ResourceContents, error) {
+			if uri != res.URI {
+				return nil, nil
+			}
+			return contents, nil
+		}),
+	)
+
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-resources", Version: "0.1.0"}),
+		mcpservice.WithResourcesCapability(resources),
+	)
+
+	// initialize + resources/list + resources/read
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	}
+	listReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  string(mcp.ResourcesListMethod),
+		"params":  map[string]any{"cursor": ""},
+	}
+	readReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  string(mcp.ResourcesReadMethod),
+		"params":  map[string]any{"uri": res.URI},
+	}
+
+	var in bytes.Buffer
+	mustWriteJSONL(t, &in, initReq)
+	mustWriteJSONL(t, &in, listReq)
+	mustWriteJSONL(t, &in, readReq)
+	var out bytes.Buffer
+
+	h := NewHandler(server, WithIO(&in, &out))
+	if err := h.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	lines := splitNonEmptyLines(out.String())
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 responses, got %d: %q", len(lines), out.String())
+	}
+
+	// resources/list
+	var listRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[1]), &listRes); err != nil {
+		t.Fatalf("unmarshal resources/list: %v", err)
+	}
+	if listRes.Error != nil {
+		t.Fatalf("resources/list error: %+v", listRes.Error)
+	}
+	var listPayload mcp.ListResourcesResult
+	if err := json.Unmarshal(listRes.Result, &listPayload); err != nil {
+		t.Fatalf("unmarshal resources payload: %v", err)
+	}
+	if len(listPayload.Resources) != 1 || listPayload.Resources[0].URI != res.URI {
+		t.Fatalf("unexpected resources payload: %+v", listPayload)
+	}
+
+	// resources/read
+	var readRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[2]), &readRes); err != nil {
+		t.Fatalf("unmarshal resources/read: %v", err)
+	}
+	if readRes.Error != nil {
+		t.Fatalf("resources/read error: %+v", readRes.Error)
+	}
+	var readPayload mcp.ReadResourceResult
+	if err := json.Unmarshal(readRes.Result, &readPayload); err != nil {
+		t.Fatalf("unmarshal read payload: %v", err)
+	}
+	if len(readPayload.Contents) != 1 || readPayload.Contents[0].Text != "hello" {
+		t.Fatalf("unexpected read payload: %+v", readPayload)
+	}
+}
+
+func TestPromptsListAndGet(t *testing.T) {
+	t.Parallel()
+
+	p := mcp.Prompt{Name: "hello", Description: "say hello"}
+	prompts := mcpservice.NewPromptsCapability(
+		mcpservice.WithListPrompts(func(_ context.Context, _ sessions.Session, _ *string) (mcpservice.Page[mcp.Prompt], error) {
+			return mcpservice.NewPage([]mcp.Prompt{p}), nil
+		}),
+		mcpservice.WithGetPrompt(func(_ context.Context, _ sessions.Session, req *mcp.GetPromptRequestReceived) (*mcp.GetPromptResult, error) {
+			if req.Name != p.Name {
+				return nil, nil
+			}
+			return &mcp.GetPromptResult{
+				Description: "say hello",
+				Messages: []mcp.PromptMessage{{
+					Role:    mcp.RoleAssistant,
+					Content: []mcp.ContentBlock{{Type: "text", Text: "hello"}},
+				}},
+			}, nil
+		}),
+	)
+
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-prompts", Version: "0.1.0"}),
+		mcpservice.WithPromptsCapability(prompts),
+	)
+
+	// initialize + prompts/list + prompts/get
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	}
+	listReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  string(mcp.PromptsListMethod),
+		"params":  map[string]any{"cursor": ""},
+	}
+	getReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  string(mcp.PromptsGetMethod),
+		"params":  map[string]any{"name": p.Name},
+	}
+
+	var in bytes.Buffer
+	mustWriteJSONL(t, &in, initReq)
+	mustWriteJSONL(t, &in, listReq)
+	mustWriteJSONL(t, &in, getReq)
+	var out bytes.Buffer
+
+	h := NewHandler(server, WithIO(&in, &out))
+	if err := h.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve returned error: %v", err)
+	}
+
+	lines := splitNonEmptyLines(out.String())
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 responses, got %d: %q", len(lines), out.String())
+	}
+
+	// prompts/list
+	var listRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[1]), &listRes); err != nil {
+		t.Fatalf("unmarshal prompts/list: %v", err)
+	}
+	if listRes.Error != nil {
+		t.Fatalf("prompts/list error: %+v", listRes.Error)
+	}
+	var listPayload mcp.ListPromptsResult
+	if err := json.Unmarshal(listRes.Result, &listPayload); err != nil {
+		t.Fatalf("unmarshal prompts payload: %v", err)
+	}
+	if len(listPayload.Prompts) != 1 || listPayload.Prompts[0].Name != p.Name {
+		t.Fatalf("unexpected prompts payload: %+v", listPayload)
+	}
+
+	// prompts/get
+	var getRes jsonrpc.Response
+	if err := json.Unmarshal([]byte(lines[2]), &getRes); err != nil {
+		t.Fatalf("unmarshal prompts/get: %v", err)
+	}
+	if getRes.Error != nil {
+		t.Fatalf("prompts/get error: %+v", getRes.Error)
+	}
+	var getPayload mcp.GetPromptResult
+	if err := json.Unmarshal(getRes.Result, &getPayload); err != nil {
+		t.Fatalf("unmarshal get payload: %v", err)
+	}
+	if len(getPayload.Messages) != 1 || getPayload.Messages[0].Content[0].Text != "hello" {
+		t.Fatalf("unexpected get payload: %+v", getPayload)
+	}
+}
+
+func TestResourcesSubscribeAndListChanged(t *testing.T) {
+	t.Parallel()
+
+	// Static resources container enables subscribe + listChanged
+	sr := mcpservice.NewStaticResources(
+		[]mcp.Resource{{URI: "res://a.txt", Name: "a.txt"}},
+		nil,
+		map[string][]mcp.ResourceContents{
+			"res://a.txt": {{URI: "res://a.txt", Text: "A"}},
+		},
+	)
+
+	resources := mcpservice.NewResourcesCapability(
+		mcpservice.WithStaticResourceContainer(sr),
+	)
+
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-res-subs", Version: "0.1.0"}),
+		mcpservice.WithResourcesCapability(resources),
+	)
+
+	// Build input: initialize -> subscribe -> (server change) -> unsubscribe
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	}
+	subReq := map[string]any{"jsonrpc": "2.0", "id": 2, "method": string(mcp.ResourcesSubscribeMethod), "params": map[string]any{"uri": "res://a.txt"}}
+	unsubReq := map[string]any{"jsonrpc": "2.0", "id": 3, "method": string(mcp.ResourcesUnsubscribeMethod), "params": map[string]any{"uri": "res://a.txt"}}
+
+	// Use pipes to simulate streaming stdio safely across goroutines
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	h := NewHandler(server, WithIO(inR, outW))
+
+	// Start a reader to prevent PipeWriter flush from blocking
+	var (
+		lines    []string
+		linesMu  sync.Mutex
+		scanDone = make(chan struct{})
+	)
+	go func() {
+		scanner := bufio.NewScanner(outR)
+		for scanner.Scan() {
+			s := strings.TrimSpace(scanner.Text())
+			if s != "" {
+				linesMu.Lock()
+				lines = append(lines, s)
+				linesMu.Unlock()
+			}
+		}
+		close(scanDone)
+	}()
+
+	// Run Serve in background
+	done := make(chan error, 1)
+	go func() { done <- h.Serve(context.Background()) }()
+
+	// Write initialize and subscribe
+	mustWriteJSONLToWriter(t, inW, initReq)
+	mustWriteJSONLToWriter(t, inW, subReq)
+
+	// Trigger a list change by adding a new resource; should yield a list_changed notification.
+	_ = sr.AddResource(context.Background(), mcp.Resource{URI: "res://b.txt", Name: "b.txt"})
+
+	// Now request unsubscribe and close input to end the handler loop gracefully
+	mustWriteJSONLToWriter(t, inW, unsubReq)
+	_ = inW.Close() // signal EOF
+
+	// Wait for Serve to return, then close output writer and wait for reader
+	<-done
+	_ = outW.Close()
+	<-scanDone
+
+	linesMu.Lock()
+	defer linesMu.Unlock()
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 messages (init, subscribe result, list_changed), got %d: %+v", len(lines), lines)
+	}
+	// Find a resources list_changed notification among messages
+	foundListChanged := false
+	for _, l := range lines {
+		var any jsonrpc.AnyMessage
+		if err := json.Unmarshal([]byte(l), &any); err != nil {
+			continue
+		}
+		if any.Type() == "notification" && any.Method == string(mcp.ResourcesListChangedNotificationMethod) {
+			foundListChanged = true
+			break
+		}
+	}
+	if !foundListChanged {
+		t.Fatalf("did not observe resources list_changed notification; outputs: %+v", lines)
+	}
+}
+
+func TestToolsListChangedNotification(t *testing.T) {
+	t.Parallel()
+
+	// Static tools container enables listChanged
+	st := mcpservice.NewStaticTools()
+	toolsCap := mcpservice.NewToolsCapability(
+		mcpservice.WithStaticToolsContainer(st),
+	)
+
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-tools-lc", Version: "0.1.0"}),
+		mcpservice.WithToolsCapability(toolsCap),
+	)
+
+	// Use pipes to simulate streaming stdio
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	// concurrent reader to drain outputs
+	var (
+		lines    []string
+		linesMu  sync.Mutex
+		scanDone = make(chan struct{})
+	)
+	go func() {
+		scanner := bufio.NewScanner(outR)
+		for scanner.Scan() {
+			s := strings.TrimSpace(scanner.Text())
+			if s != "" {
+				linesMu.Lock()
+				lines = append(lines, s)
+				linesMu.Unlock()
+			}
+		}
+		close(scanDone)
+	}()
+
+	h := NewHandler(server, WithIO(inR, outW))
+	done := make(chan error, 1)
+	go func() { done <- h.Serve(context.Background()) }()
+
+	// Write initialize
+	mustWriteJSONLToWriter(t, inW, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	})
+	// Send a ping to ensure we've passed the post-initialize registration boundary
+	mustWriteJSONLToWriter(t, inW, map[string]any{"jsonrpc": "2.0", "id": 2, "method": string(mcp.PingMethod)})
+
+	// Wait for initialize + ping response so listChanged registration is active
+	waitForLines(t, &linesMu, &lines, 2)
+
+	// Trigger tools change -> should emit list_changed
+	st.Add(context.Background(), mcpservice.StaticTool{
+		Descriptor: mcp.Tool{Name: "noop", InputSchema: mcp.ToolInputSchema{Type: "object"}},
+		Handler: func(ctx context.Context, _ sessions.Session, _ *mcp.CallToolRequestReceived) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{}, nil
+		},
+	})
+
+	// Wait for the tools list_changed notification to appear
+	waitForNotification(t, &linesMu, &lines, string(mcp.ToolsListChangedNotificationMethod))
+
+	_ = inW.Close() // signal EOF
+	<-done
+	_ = outW.Close()
+	<-scanDone
+
+	linesMu.Lock()
+	defer linesMu.Unlock()
+	found := false
+	for _, l := range lines {
+		var any jsonrpc.AnyMessage
+		if err := json.Unmarshal([]byte(l), &any); err != nil {
+			continue
+		}
+		if any.Type() == "notification" && any.Method == string(mcp.ToolsListChangedNotificationMethod) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("did not observe tools list_changed notification; outputs: %+v", lines)
+	}
+}
+
+func TestPromptsListChangedNotification(t *testing.T) {
+	t.Parallel()
+
+	sp := mcpservice.NewStaticPrompts()
+	promptsCap := mcpservice.NewPromptsCapability(
+		mcpservice.WithStaticPromptsContainer(sp),
+	)
+
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "stdio-prompts-lc", Version: "0.1.0"}),
+		mcpservice.WithPromptsCapability(promptsCap),
+	)
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	var (
+		lines    []string
+		linesMu  sync.Mutex
+		scanDone = make(chan struct{})
+	)
+	go func() {
+		scanner := bufio.NewScanner(outR)
+		for scanner.Scan() {
+			s := strings.TrimSpace(scanner.Text())
+			if s != "" {
+				linesMu.Lock()
+				lines = append(lines, s)
+				linesMu.Unlock()
+			}
+		}
+		close(scanDone)
+	}()
+
+	h := NewHandler(server, WithIO(inR, outW))
+	done := make(chan error, 1)
+	go func() { done <- h.Serve(context.Background()) }()
+
+	mustWriteJSONLToWriter(t, inW, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  string(mcp.InitializeMethod),
+		"params": map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "0.0.0"},
+		},
+	})
+
+	// Send a ping to ensure we've passed the post-initialize registration boundary
+	mustWriteJSONLToWriter(t, inW, map[string]any{"jsonrpc": "2.0", "id": 2, "method": string(mcp.PingMethod)})
+
+	// Wait for initialize + ping response so listChanged registration is active
+	waitForLines(t, &linesMu, &lines, 2)
+
+	// Trigger prompts change -> should emit list_changed
+	sp.Add(context.Background(), mcpservice.StaticPrompt{
+		Descriptor: mcp.Prompt{Name: "hi"},
+		Handler: func(ctx context.Context, _ sessions.Session, _ *mcp.GetPromptRequestReceived) (*mcp.GetPromptResult, error) {
+			return &mcp.GetPromptResult{Messages: []mcp.PromptMessage{}}, nil
+		},
+	})
+
+	// Wait for the prompts list_changed notification to appear
+	waitForNotification(t, &linesMu, &lines, string(mcp.PromptsListChangedNotificationMethod))
+
+	_ = inW.Close()
+	<-done
+	_ = outW.Close()
+	<-scanDone
+
+	linesMu.Lock()
+	defer linesMu.Unlock()
+	found := false
+	for _, l := range lines {
+		var any jsonrpc.AnyMessage
+		if err := json.Unmarshal([]byte(l), &any); err != nil {
+			continue
+		}
+		if any.Type() == "notification" && any.Method == string(mcp.PromptsListChangedNotificationMethod) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("did not observe prompts list_changed notification; outputs: %+v", lines)
+	}
+}
+
+// helpers
+func mustWriteJSONL(t *testing.T, buf *bytes.Buffer, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := buf.Write(append(b, '\n')); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func splitNonEmptyLines(s string) []string {
+	raw := strings.Split(s, "\n")
+	out := make([]string, 0, len(raw))
+	for _, l := range raw {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// Write helper for io.Writer targets (e.g., pipes)
+func mustWriteJSONLToWriter(t *testing.T, w io.Writer, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// waitForLines waits until the collected output lines reach at least n, or times out.
+func waitForLines(t *testing.T, mu *sync.Mutex, lines *[]string, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		l := len(*lines)
+		mu.Unlock()
+		if l >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	mu.Lock()
+	l := len(*lines)
+	mu.Unlock()
+	t.Fatalf("timeout waiting for %d lines, saw %d", n, l)
+}
+
+// waitForNotification waits until a notification with the given method appears in the collected lines.
+func waitForNotification(t *testing.T, mu *sync.Mutex, lines *[]string, method string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		snapshot := append([]string(nil), (*lines)...)
+		mu.Unlock()
+		for _, l := range snapshot {
+			var any jsonrpc.AnyMessage
+			if err := json.Unmarshal([]byte(l), &any); err != nil {
+				continue
+			}
+			if any.Type() == "notification" && any.Method == method {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for notification %q", method)
+}

--- a/stdio/handler_test.go
+++ b/stdio/handler_test.go
@@ -424,6 +424,8 @@ func TestResourcesSubscribeAndListChanged(t *testing.T) {
 
 	// Trigger a list change by adding a new resource; should yield a list_changed notification.
 	_ = sr.AddResource(context.Background(), mcp.Resource{URI: "res://b.txt", Name: "b.txt"})
+	// Wait until we observe the notification before proceeding to avoid race with shutdown.
+	waitForNotification(t, &linesMu, &lines, string(mcp.ResourcesListChangedNotificationMethod))
 
 	// Now request unsubscribe and close input to end the handler loop gracefully
 	mustWriteJSONLToWriter(t, inW, unsubReq)

--- a/stdio/options.go
+++ b/stdio/options.go
@@ -1,0 +1,57 @@
+package stdio
+
+import (
+	"io"
+	"log/slog"
+)
+
+// Option customizes a Handler.
+type Option func(*Handler)
+
+// WithIO sets the reader and writer for the handler.
+func WithIO(r io.Reader, w io.Writer) Option {
+	return func(h *Handler) {
+		if r != nil {
+			h.r = r
+		}
+		if w != nil {
+			h.w = w
+		}
+	}
+}
+
+// WithReader overrides the input stream.
+func WithReader(r io.Reader) Option {
+	return func(h *Handler) {
+		if r != nil {
+			h.r = r
+		}
+	}
+}
+
+// WithWriter overrides the output stream.
+func WithWriter(w io.Writer) Option {
+	return func(h *Handler) {
+		if w != nil {
+			h.w = w
+		}
+	}
+}
+
+// WithLogger overrides the logger.
+func WithLogger(l *slog.Logger) Option {
+	return func(h *Handler) {
+		if l != nil {
+			h.l = l
+		}
+	}
+}
+
+// WithUserProvider overrides the user provider used for authless identification.
+func WithUserProvider(up UserProvider) Option {
+	return func(h *Handler) {
+		if up != nil {
+			h.userProvider = up
+		}
+	}
+}

--- a/stdio/outbound_dispatcher.go
+++ b/stdio/outbound_dispatcher.go
@@ -3,180 +3,43 @@ package stdio
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"sync"
-	"sync/atomic"
 
 	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
-	"github.com/ggoodman/mcp-server-go/mcp"
+	"github.com/ggoodman/mcp-server-go/internal/outbound"
 )
 
 // jsonrpcWriter is the minimal writer contract backed by writeMux.
-type jsonrpcWriter interface {
-	writeJSONRPC(v any) error
+type jsonrpcWriter interface{ writeJSONRPC(v any) error }
+
+// stdioTransport implements outbound.Transport over writeMux.
+type stdioTransport struct{ w jsonrpcWriter }
+
+func (t stdioTransport) SendRequest(ctx context.Context, id *jsonrpc.RequestID, req *jsonrpc.Request) error {
+	return t.w.writeJSONRPC(req)
+}
+func (t stdioTransport) SendCancelled(ctx context.Context, requestID string) error {
+	n := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: "notifications/cancelled", Params: mustJSON(map[string]any{"requestId": requestID})}
+	return t.w.writeJSONRPC(n)
 }
 
-var (
-	// ErrDispatcherClosed indicates the dispatcher is closed.
-	ErrDispatcherClosed = errors.New("dispatcher closed")
-	// ErrRemoteCancelled indicates the peer cancelled the request.
-	ErrRemoteCancelled = errors.New("remote cancelled")
-)
-
-type pendingCall struct {
-	respCh chan *jsonrpc.Response
-	errCh  chan error
-}
-
-// outboundDispatcher coordinates server-initiated JSON-RPC requests over stdio.
-type outboundDispatcher struct {
-	w jsonrpcWriter
-
-	mu      sync.Mutex
-	pending map[string]*pendingCall // id.String() -> call
-
-	nextID uint64
-
-	closed   atomic.Bool
-	closeErr error
-}
+// outboundDispatcher wraps the internal dispatcher to preserve tests and API.
+type outboundDispatcher struct{ d *outbound.Dispatcher }
 
 func newOutboundDispatcher(w jsonrpcWriter) *outboundDispatcher {
-	return &outboundDispatcher{
-		w:       w,
-		pending: make(map[string]*pendingCall),
-	}
+	return &outboundDispatcher{d: outbound.New(stdioTransport{w: w})}
 }
 
-// Call sends a JSON-RPC request and waits for a response or context cancellation.
 func (d *outboundDispatcher) Call(ctx context.Context, method string, params any) (*jsonrpc.Response, error) {
-	if d.closed.Load() {
-		if d.closeErr != nil {
-			return nil, d.closeErr
-		}
-		return nil, ErrDispatcherClosed
-	}
-
-	// Allocate ID
-	idNum := atomic.AddUint64(&d.nextID, 1)
-	id := jsonrpc.NewRequestID(idNum)
-	key := id.String()
-
-	// Marshal params
-	var paramsRaw json.RawMessage
-	if params != nil {
-		b, err := json.Marshal(params)
-		if err != nil {
-			return nil, fmt.Errorf("marshal params: %w", err)
-		}
-		paramsRaw = b
-	}
-
-	// Register pending
-	pc := &pendingCall{respCh: make(chan *jsonrpc.Response, 1), errCh: make(chan error, 1)}
-	d.mu.Lock()
-	if d.closed.Load() {
-		d.mu.Unlock()
-		if d.closeErr != nil {
-			return nil, d.closeErr
-		}
-		return nil, ErrDispatcherClosed
-	}
-	d.pending[key] = pc
-	d.mu.Unlock()
-
-	// Send request
-	req := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: method, Params: paramsRaw, ID: id}
-	if err := d.w.writeJSONRPC(req); err != nil {
-		d.mu.Lock()
-		delete(d.pending, key)
-		d.mu.Unlock()
-		return nil, err
-	}
-
-	// Await response or cancellation
-	select {
-	case resp := <-pc.respCh:
-		return resp, nil
-	case err := <-pc.errCh:
-		if err != nil {
-			return nil, err
-		}
-		return nil, ErrDispatcherClosed
-	case <-ctx.Done():
-		// Best-effort cancel message to client
-		_ = d.w.writeJSONRPC(&jsonrpc.Request{
-			JSONRPCVersion: jsonrpc.ProtocolVersion,
-			Method:         string(mcp.CancelledNotificationMethod),
-			Params:         mustJSON(mcp.CancelledNotification{RequestID: key}),
-		})
-		d.mu.Lock()
-		delete(d.pending, key)
-		d.mu.Unlock()
-		return nil, ctx.Err()
-	}
+	return d.d.Call(ctx, method, params)
 }
+func (d *outboundDispatcher) OnResponse(resp *jsonrpc.Response)     { d.d.OnResponse(resp) }
+func (d *outboundDispatcher) OnNotification(any jsonrpc.AnyMessage) { d.d.OnNotification(any) }
+func (d *outboundDispatcher) Close(err error)                       { d.d.Close(err) }
 
-// OnResponse delivers an incoming response to a waiting call. Unmatched responses are ignored.
-func (d *outboundDispatcher) OnResponse(resp *jsonrpc.Response) {
-	if resp == nil || resp.ID == nil {
-		return
-	}
-	key := resp.ID.String()
-	d.mu.Lock()
-	pc, ok := d.pending[key]
-	if ok {
-		delete(d.pending, key)
-	}
-	d.mu.Unlock()
-	if ok {
-		pc.respCh <- resp
-	}
-}
+func mustJSON(v any) json.RawMessage { b, _ := json.Marshal(v); return b }
 
-// OnNotification processes peer notifications relevant to outbound calls (cancel/progress).
-func (d *outboundDispatcher) OnNotification(any jsonrpc.AnyMessage) {
-	switch any.Method {
-	case string(mcp.CancelledNotificationMethod):
-		var p mcp.CancelledNotification
-		if err := json.Unmarshal(any.Params, &p); err != nil {
-			return
-		}
-		key := p.RequestID
-		d.mu.Lock()
-		pc, ok := d.pending[key]
-		if ok {
-			delete(d.pending, key)
-		}
-		d.mu.Unlock()
-		if ok {
-			pc.errCh <- ErrRemoteCancelled
-		}
-	case string(mcp.ProgressNotificationMethod):
-		// Currently ignored; kept for forward compatibility.
-		return
-	}
-}
-
-// Close cancels all pending calls with the provided error and prevents new calls.
-func (d *outboundDispatcher) Close(err error) {
-	if !d.closed.CompareAndSwap(false, true) {
-		return
-	}
-	if err == nil {
-		err = ErrDispatcherClosed
-	}
-	d.closeErr = err
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	for key, pc := range d.pending {
-		delete(d.pending, key)
-		pc.errCh <- err
-	}
-}
-
-func mustJSON(v any) json.RawMessage {
-	b, _ := json.Marshal(v)
-	return b
-}
+// Re-export common errors for compatibility with existing tests/consumers.
+var (
+	ErrDispatcherClosed = outbound.ErrDispatcherClosed
+	ErrRemoteCancelled  = outbound.ErrRemoteCancelled
+)

--- a/stdio/outbound_dispatcher.go
+++ b/stdio/outbound_dispatcher.go
@@ -1,0 +1,182 @@
+package stdio
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/mcp"
+)
+
+// jsonrpcWriter is the minimal writer contract backed by writeMux.
+type jsonrpcWriter interface {
+	writeJSONRPC(v any) error
+}
+
+var (
+	// ErrDispatcherClosed indicates the dispatcher is closed.
+	ErrDispatcherClosed = errors.New("dispatcher closed")
+	// ErrRemoteCancelled indicates the peer cancelled the request.
+	ErrRemoteCancelled = errors.New("remote cancelled")
+)
+
+type pendingCall struct {
+	respCh chan *jsonrpc.Response
+	errCh  chan error
+}
+
+// outboundDispatcher coordinates server-initiated JSON-RPC requests over stdio.
+type outboundDispatcher struct {
+	w jsonrpcWriter
+
+	mu      sync.Mutex
+	pending map[string]*pendingCall // id.String() -> call
+
+	nextID uint64
+
+	closed   atomic.Bool
+	closeErr error
+}
+
+func newOutboundDispatcher(w jsonrpcWriter) *outboundDispatcher {
+	return &outboundDispatcher{
+		w:       w,
+		pending: make(map[string]*pendingCall),
+	}
+}
+
+// Call sends a JSON-RPC request and waits for a response or context cancellation.
+func (d *outboundDispatcher) Call(ctx context.Context, method string, params any) (*jsonrpc.Response, error) {
+	if d.closed.Load() {
+		if d.closeErr != nil {
+			return nil, d.closeErr
+		}
+		return nil, ErrDispatcherClosed
+	}
+
+	// Allocate ID
+	idNum := atomic.AddUint64(&d.nextID, 1)
+	id := jsonrpc.NewRequestID(idNum)
+	key := id.String()
+
+	// Marshal params
+	var paramsRaw json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return nil, fmt.Errorf("marshal params: %w", err)
+		}
+		paramsRaw = b
+	}
+
+	// Register pending
+	pc := &pendingCall{respCh: make(chan *jsonrpc.Response, 1), errCh: make(chan error, 1)}
+	d.mu.Lock()
+	if d.closed.Load() {
+		d.mu.Unlock()
+		if d.closeErr != nil {
+			return nil, d.closeErr
+		}
+		return nil, ErrDispatcherClosed
+	}
+	d.pending[key] = pc
+	d.mu.Unlock()
+
+	// Send request
+	req := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: method, Params: paramsRaw, ID: id}
+	if err := d.w.writeJSONRPC(req); err != nil {
+		d.mu.Lock()
+		delete(d.pending, key)
+		d.mu.Unlock()
+		return nil, err
+	}
+
+	// Await response or cancellation
+	select {
+	case resp := <-pc.respCh:
+		return resp, nil
+	case err := <-pc.errCh:
+		if err != nil {
+			return nil, err
+		}
+		return nil, ErrDispatcherClosed
+	case <-ctx.Done():
+		// Best-effort cancel message to client
+		_ = d.w.writeJSONRPC(&jsonrpc.Request{
+			JSONRPCVersion: jsonrpc.ProtocolVersion,
+			Method:         string(mcp.CancelledNotificationMethod),
+			Params:         mustJSON(mcp.CancelledNotification{RequestID: key}),
+		})
+		d.mu.Lock()
+		delete(d.pending, key)
+		d.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+// OnResponse delivers an incoming response to a waiting call. Unmatched responses are ignored.
+func (d *outboundDispatcher) OnResponse(resp *jsonrpc.Response) {
+	if resp == nil || resp.ID == nil {
+		return
+	}
+	key := resp.ID.String()
+	d.mu.Lock()
+	pc, ok := d.pending[key]
+	if ok {
+		delete(d.pending, key)
+	}
+	d.mu.Unlock()
+	if ok {
+		pc.respCh <- resp
+	}
+}
+
+// OnNotification processes peer notifications relevant to outbound calls (cancel/progress).
+func (d *outboundDispatcher) OnNotification(any jsonrpc.AnyMessage) {
+	switch any.Method {
+	case string(mcp.CancelledNotificationMethod):
+		var p mcp.CancelledNotification
+		if err := json.Unmarshal(any.Params, &p); err != nil {
+			return
+		}
+		key := p.RequestID
+		d.mu.Lock()
+		pc, ok := d.pending[key]
+		if ok {
+			delete(d.pending, key)
+		}
+		d.mu.Unlock()
+		if ok {
+			pc.errCh <- ErrRemoteCancelled
+		}
+	case string(mcp.ProgressNotificationMethod):
+		// Currently ignored; kept for forward compatibility.
+		return
+	}
+}
+
+// Close cancels all pending calls with the provided error and prevents new calls.
+func (d *outboundDispatcher) Close(err error) {
+	if !d.closed.CompareAndSwap(false, true) {
+		return
+	}
+	if err == nil {
+		err = ErrDispatcherClosed
+	}
+	d.closeErr = err
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for key, pc := range d.pending {
+		delete(d.pending, key)
+		pc.errCh <- err
+	}
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/stdio/outbound_dispatcher_test.go
+++ b/stdio/outbound_dispatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -159,7 +160,7 @@ func TestOutboundDispatcher_RemoteCancelled(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		_, err := d.Call(ctx, "test/m", nil)
-		if !errorsIs(err, ErrRemoteCancelled) {
+		if !errors.Is(err, ErrRemoteCancelled) {
 			t.Errorf("expected ErrRemoteCancelled, got %v", err)
 		}
 	}()
@@ -175,8 +176,4 @@ func TestOutboundDispatcher_RemoteCancelled(t *testing.T) {
 	notif := jsonrpc.AnyMessage{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: "notifications/cancelled", Params: mustJSON(map[string]any{"requestId": req.ID.String()})}
 	d.OnNotification(notif)
 	wg.Wait()
-}
-
-func errorsIs(err, target error) bool {
-	return (err != nil && target != nil && err.Error() == target.Error())
 }

--- a/stdio/outbound_dispatcher_test.go
+++ b/stdio/outbound_dispatcher_test.go
@@ -1,0 +1,182 @@
+package stdio
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+)
+
+// writeMux implements jsonrpcWriter for tests via the real mux.
+func newTestMux(buf *bytes.Buffer) *writeMux { return &writeMux{w: bufio.NewWriter(buf)} }
+
+func readLines(t *testing.T, s string) []string {
+	t.Helper()
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func waitForBufferLines(t *testing.T, mux *writeMux, buf *bytes.Buffer, n int, timeout time.Duration) []string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		_ = mux.w.Flush()
+		lines := readLines(t, buf.String())
+		if len(lines) >= n {
+			return lines
+		}
+		if time.Now().After(deadline) {
+			return lines
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestOutboundDispatcher_RequestResponse_OutOfOrder(t *testing.T) {
+	t.Parallel()
+
+	var w bytes.Buffer
+	mux := newTestMux(&w)
+	d := newOutboundDispatcher(mux)
+
+	ctx := context.Background()
+
+	// Issue two requests
+	resCh1 := make(chan *jsonrpc.Response, 1)
+	resCh2 := make(chan *jsonrpc.Response, 1)
+
+	go func() {
+		resp, err := d.Call(ctx, "test/m1", map[string]any{"a": 1})
+		if err != nil {
+			t.Errorf("call1: %v", err)
+			return
+		}
+		resCh1 <- resp
+	}()
+	go func() {
+		resp, err := d.Call(ctx, "test/m2", map[string]any{"b": 2})
+		if err != nil {
+			t.Errorf("call2: %v", err)
+			return
+		}
+		resCh2 <- resp
+	}()
+
+	// Extract written requests from buffer
+	lines := waitForBufferLines(t, mux, &w, 2, time.Second)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 outbound requests, got %d", len(lines))
+	}
+	var req1, req2 jsonrpc.Request
+	_ = json.Unmarshal([]byte(lines[0]), &req1)
+	_ = json.Unmarshal([]byte(lines[1]), &req2)
+
+	// Reply out of order: respond to req2 first
+	resp2, _ := jsonrpc.NewResultResponse(req2.ID, map[string]any{"ok": 2})
+	d.OnResponse(resp2)
+	resp1, _ := jsonrpc.NewResultResponse(req1.ID, map[string]any{"ok": 1})
+	d.OnResponse(resp1)
+
+	// Validate
+	got2 := <-resCh2
+	got1 := <-resCh1
+	if got2.Error != nil || got1.Error != nil {
+		t.Fatalf("unexpected errors: %+v %+v", got2.Error, got1.Error)
+	}
+}
+
+func TestOutboundDispatcher_CancelContext_SendsCancelled(t *testing.T) {
+	t.Parallel()
+
+	var w bytes.Buffer
+	mux := newTestMux(&w)
+	d := newOutboundDispatcher(mux)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := d.Call(ctx, "test/m", nil)
+		done <- err
+	}()
+
+	// Find the request ID written
+	lines := waitForBufferLines(t, mux, &w, 1, time.Second)
+	if len(lines) < 1 {
+		t.Fatalf("expected at least 1 outbound request, got %d", len(lines))
+	}
+	var req jsonrpc.Request
+	_ = json.Unmarshal([]byte(lines[0]), &req)
+
+	// Cancel the context
+	cancel()
+	err := <-done
+	if err == nil {
+		t.Fatalf("expected error from cancelled call")
+	}
+
+	// A notifications/cancelled should have been written
+	lines = waitForBufferLines(t, mux, &w, 2, time.Second)
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 outbound messages (request + cancel), got %d", len(lines))
+	}
+	// Last line should be cancelled notification referencing req.ID
+	var last jsonrpc.AnyMessage
+	_ = json.Unmarshal([]byte(lines[len(lines)-1]), &last)
+	if last.Method == "" || last.Method != "notifications/cancelled" {
+		t.Fatalf("expected cancelled notification, got %s", last.Method)
+	}
+	var p struct {
+		RequestID string `json:"requestId"`
+	}
+	_ = json.Unmarshal(last.Params, &p)
+	if p.RequestID != req.ID.String() {
+		t.Fatalf("cancelled requestId mismatch: got %s want %s", p.RequestID, req.ID.String())
+	}
+}
+
+func TestOutboundDispatcher_RemoteCancelled(t *testing.T) {
+	t.Parallel()
+
+	var w bytes.Buffer
+	mux := newTestMux(&w)
+	d := newOutboundDispatcher(mux)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := d.Call(ctx, "test/m", nil)
+		if !errorsIs(err, ErrRemoteCancelled) {
+			t.Errorf("expected ErrRemoteCancelled, got %v", err)
+		}
+	}()
+
+	lines := waitForBufferLines(t, mux, &w, 1, time.Second)
+	if len(lines) < 1 {
+		t.Fatalf("expected at least 1 outbound request, got %d", len(lines))
+	}
+	var req jsonrpc.Request
+	_ = json.Unmarshal([]byte(lines[0]), &req)
+
+	// Simulate client notifications/cancelled
+	notif := jsonrpc.AnyMessage{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: "notifications/cancelled", Params: mustJSON(map[string]any{"requestId": req.ID.String()})}
+	d.OnNotification(notif)
+	wg.Wait()
+}
+
+func errorsIs(err, target error) bool {
+	return (err != nil && target != nil && err.Error() == target.Error())
+}

--- a/stdio/user.go
+++ b/stdio/user.go
@@ -1,0 +1,27 @@
+package stdio
+
+import (
+	"os/user"
+)
+
+// UserProvider provides a string user ID to associate with the stdio peer.
+// For stdio, we don't pass or validate bearer tokens; this mirrors the library's
+// examples where local development often uses a fixed or environment-derived ID.
+type UserProvider interface {
+	CurrentUserID() (string, error)
+}
+
+// OSUserProvider resolves the user ID using the operating system's current user.
+// The returned ID is user.Username when available; falling back to user.Uid.
+type OSUserProvider struct{}
+
+func (OSUserProvider) CurrentUserID() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	if u.Username != "" {
+		return u.Username, nil
+	}
+	return u.Uid, nil
+}

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elnormous/contenttype"
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/internal/outbound"
 	"github.com/ggoodman/mcp-server-go/internal/sessioncore"
 	"github.com/ggoodman/mcp-server-go/internal/wellknown"
 	"github.com/ggoodman/mcp-server-go/mcp"
@@ -134,6 +135,11 @@ type StreamingHTTPHandler struct {
 	sessMu      sync.Mutex
 	sessParents map[string]context.Context
 	sessCancel  map[string]context.CancelFunc
+
+	// Per-session outbound dispatchers and their cancel/unsub handlers for
+	// long-lived subscriptions (e.g., notifications/cancelled).
+	dispMu      sync.Mutex
+	dispatchers map[string]*outboundDispatcherHolder
 }
 
 // lockedWriteFlusher wraps an io.Writer + http.Flusher with a mutex and an optional context.
@@ -725,6 +731,9 @@ func (h *StreamingHTTPHandler) handleGetMCP(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Cache-Control", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	wf.Flush()
+
+	// Ensure per-session outbound dispatcher exists and is wired to cancelled notifications.
+	_ = h.ensureDispatcher(ctx, sh)
 
 	// Requests to the GET /mcp endpoint MUST be in the context of an already
 	// established session. Session establishment can only happen in POST /mcp.
@@ -1543,4 +1552,123 @@ func (h *StreamingHTTPHandler) teardownSession(sessionID string) {
 		delete(h.subCancels, sessionID)
 	}
 	h.subMu.Unlock()
+
+	// Also close outbound dispatcher and unsubscribe from cancelled listener.
+	h.dispMu.Lock()
+	if h.dispatchers != nil {
+		if holder, ok := h.dispatchers[sessionID]; ok && holder != nil {
+			if holder.cancelledUnsub != nil {
+				holder.cancelledUnsub()
+			}
+			holder.d.Close(context.Canceled)
+			delete(h.dispatchers, sessionID)
+		}
+	}
+	h.dispMu.Unlock()
+}
+
+// --- Outbound dispatcher integration ---
+
+// Holder for per-session dispatcher and unsubs.
+type outboundDispatcherHolder struct {
+	d *outbound.Dispatcher
+	// unsubscribe from notifications/cancelled stream
+	cancelledUnsub func()
+}
+
+// streamingTransport implements outbound.Transport over the sessionHost/session.
+type streamingTransport struct {
+	h  *StreamingHTTPHandler
+	sh *sessioncore.SessionHandle // for SessionID, WriteMessage
+}
+
+func (t streamingTransport) SendRequest(ctx context.Context, id *jsonrpc.RequestID, req *jsonrpc.Request) error {
+	// Subscribe to rv:<id> before emitting request to avoid missing responses.
+	key := "rv:" + id.String()
+	var unsub func()
+	var err error
+	unsub, err = t.h.sessionHost.SubscribeEvents(ctx, t.sh.SessionID(), key, func(evtCtx context.Context, payload []byte) error {
+		var resp jsonrpc.Response
+		if err := json.Unmarshal(payload, &resp); err != nil {
+			return err
+		}
+		// Route to the session's dispatcher if still present.
+		if d := t.h.getDispatcher(t.sh.SessionID()); d != nil {
+			d.OnResponse(&resp)
+		}
+		// One-shot responders: we can unsubscribe on first message.
+		if unsub != nil {
+			unsub()
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// Emit request to client.
+	b, err := json.Marshal(req)
+	if err != nil {
+		unsub()
+		return err
+	}
+	if err := t.sh.WriteMessage(ctx, b); err != nil {
+		unsub()
+		return err
+	}
+	return nil
+}
+
+func (t streamingTransport) SendCancelled(ctx context.Context, requestID string) error {
+	// Build params raw message
+	p := struct {
+		RequestID string `json:"requestId"`
+	}{RequestID: requestID}
+	pb, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	n := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: string(mcp.CancelledNotificationMethod), Params: pb}
+	b, err := json.Marshal(n)
+	if err != nil {
+		return err
+	}
+	return t.sh.WriteMessage(ctx, b)
+}
+
+// ensureDispatcher creates or returns the per-session dispatcher and wires the
+// notifications/cancelled subscription. Safe for concurrent calls.
+func (h *StreamingHTTPHandler) ensureDispatcher(ctx context.Context, sh *sessioncore.SessionHandle) *outbound.Dispatcher {
+	h.dispMu.Lock()
+	defer h.dispMu.Unlock()
+	if h.dispatchers == nil {
+		h.dispatchers = make(map[string]*outboundDispatcherHolder)
+	}
+	if holder, ok := h.dispatchers[sh.SessionID()]; ok && holder != nil {
+		return holder.d
+	}
+
+	// Create dispatcher
+	d := outbound.New(streamingTransport{h: h, sh: sh})
+
+	// Subscribe to notifications/cancelled and forward to dispatcher.
+	unsub, err := h.sessionHost.SubscribeEvents(h.ensureSessionParentContext(ctx, sh.SessionID()), sh.SessionID(), string(mcp.CancelledNotificationMethod), func(evtCtx context.Context, payload []byte) error {
+		any := jsonrpc.AnyMessage{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: string(mcp.CancelledNotificationMethod), Params: payload}
+		d.OnNotification(any)
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+
+	h.dispatchers[sh.SessionID()] = &outboundDispatcherHolder{d: d, cancelledUnsub: unsub}
+	return d
+}
+
+func (h *StreamingHTTPHandler) getDispatcher(sessionID string) *outbound.Dispatcher {
+	h.dispMu.Lock()
+	defer h.dispMu.Unlock()
+	if holder, ok := h.dispatchers[sessionID]; ok && holder != nil {
+		return holder.d
+	}
+	return nil
 }

--- a/todo/process-api-sessions.md
+++ b/todo/process-api-sessions.md
@@ -1,0 +1,102 @@
+# Sessions Process API (Plan)
+
+Objective: enable full MCP client-side capabilities (sampling, roots, elicitation) over stdio by introducing a robust outbound JSON-RPC pipeline and wiring it into `sessions.Session` for the stdio transport.
+
+## Scope
+
+- Outbound JSON-RPC core for server-initiated requests
+- Cancellation and progress routing for outbound calls
+- Session client capability adapters using the dispatcher
+- Minimal server-side parity improvements that unblock protocol expectations
+- Tests that stress concurrency, ordering, and lifecycle
+
+## Design
+
+### 1) Outbound JSON-RPC Dispatcher
+
+Contract:
+
+- Call(ctx, method, params) -> (result json.RawMessage, err)
+- SendNotification(method, params) error (for `notifications/cancelled`, optional now)
+- OnResponse(resp \*jsonrpc.Response) to resolve pending calls
+- OnNotification(any jsonrpc.AnyMessage) for progress/cancel handling
+- Close(err) to fail all pending with the given error
+
+Details:
+
+- ID generation: monotonic uint64 increment, wrapped by `jsonrpc.NewRequestID`.
+- Pending: map[*jsonrpc.RequestID]pending; pending holds a result channel and optional progress sink; guarded by mutex.
+- Write path: reuse `writeMux` to serialize writes; marshal a `jsonrpc.Request` with method/params/id.
+- Read path integration: when `AnyMessage.Type()=="response"`, call dispatcher.OnResponse().
+- Context cancellation: if ctx.Done() before response, fire `notifications/cancelled` with the same id (best-effort), remove pending, return ctx.Err().
+- Shutdown: Close() cancels all pending with a terminal error (e.g., io.EOF or context.Canceled) and prevents new calls.
+
+Edge cases:
+
+- Out-of-order responses: resolved by pending map lookup.
+- Stray responses: ignore (no pending).
+- Duplicate IDs: impossible via local generator; guard anyway.
+
+### 2) Progress and Cancellation Notifications
+
+- Progress: observe `notifications/progress` carrying `progressToken`. Initially, we’ll parse and drop unless a future API wires a callback. Keep a token->callback map for forward compatibility; no-op if none.
+- Cancelled: observe `notifications/cancelled` referencing a requestId. If it matches a pending outbound call, cancel and complete it with a clear error (e.g., ErrRemoteCancelled).
+
+### 3) stdio Session Capability Adapters
+
+Attach to `stdioSession`:
+
+- SamplingCapability
+  - CreateMessage(ctx, req) -> outbound `sampling/createMessage`; return decoded `mcp.CreateMessageResult`.
+  - Pass through ctx cancel; no-op on progress for now.
+- RootsCapability
+  - ListRoots(ctx) -> outbound `roots/list`.
+  - RegisterRootsListChangedListener(ctx, fn): store listener; enable after client `notifications/initialized`; on `notifications/roots/list_changed` run listeners (ordered, best-effort).
+- ElicitationCapability
+  - Elicit(ctx, req) -> outbound `elicitation/create`.
+
+Sequencing:
+
+- Server should only initiate outbound calls after client `notifications/initialized` observed, mirroring current listChanged gating.
+
+### 4) Server-side Parity (small)
+
+- resources/templates/list: implement in `handleRequest` using `mcpservice.ResourcesCapability` if available.
+- resources/updated: if the resources container exposes granular update hooks, register alongside listChanged and emit `notifications/resources/updated`.
+- logging/setLevel: optional; wire to a hook to update logger level.
+
+### 5) Testing Strategy
+
+Dispatcher unit tests (table-driven):
+
+- Happy path: two concurrent outbound calls, responses arrive out of order.
+- Cancellation: ctx canceled before response sends `notifications/cancelled` and returns context error.
+- Remote cancel: incoming `notifications/cancelled` aborts matching call.
+- Shutdown: Close() cancels all pending and prevents new calls.
+
+Session adapter integration tests (stdio):
+
+- sampling/createMessage: client sends response; also test cancellation.
+- roots/list: returns roots; sending `notifications/roots/list_changed` triggers registered listener.
+- elicitation/create: happy path.
+
+Transport sequencing:
+
+- Ensure no server-initiated calls until client `notifications/initialized`.
+
+### 6) Open Questions
+
+- Progress surfacing: do we want to extend `sessions.SamplingCapability` to support progress callbacks, or keep the server blind to progress for now?
+- Logging setLevel: should we expose a provider to map levels to the underlying slog instance, or keep a no-op default?
+- Backpressure: if a client floods progress notifications, we currently drop them; acceptable for now.
+
+## Incremental Plan
+
+1. Implement dispatcher and tests (no capability wiring yet).
+2. Wire dispatcher into stdio handler (route responses/notifications) and expose on `stdioSession`.
+3. Implement SamplingCapability via dispatcher (+ tests).
+4. Implement RootsCapability (+ notifications/roots/list_changed) (+ tests).
+5. Implement ElicitationCapability (+ tests).
+6. Add resources/templates/list and resources/updated forwarding (+ tests).
+
+This gives us a hardened base to support remaining features without reworking IO or lifecycles later.


### PR DESCRIPTION
Introduce a new `stdio` transport package that allows running an MCP server over standard input/output, enhancing local development and subprocess integration. The implementation includes user identification, customizable IO options, and an outbound dispatcher for handling JSON-RPC requests.