### PR TITLE
Fix SSE message encoding and improve logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/examples/readme"
+      "program": "${workspaceFolder}/examples/readme",
+      "envFile": "${workspaceFolder}/examples/readme/.env"
     }
   ]
 }

--- a/examples/readme/.env.example
+++ b/examples/readme/.env.example
@@ -1,0 +1,3 @@
+MCP_PUBLIC_ENDPOINT=https://example.com/mcp
+OIDC_ISSUER=https://auth.example.com/
+REDIS_ADDR=127.0.0.1:6379

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -62,6 +62,8 @@ func main() {
 		panic(err)
 	}
 
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
 	// 5) Drop-in handler
 	h, err := streaminghttp.New(
 		ctx,
@@ -70,7 +72,7 @@ func main() {
 		server,
 		authenticator,
 		streaminghttp.WithServerName("My MCP Server"),
-		streaminghttp.WithLogger(slog.NewTextHandler(os.Stdout, nil)),
+		streaminghttp.WithLogger(log),
 		streaminghttp.WithAuthorizationServerDiscovery(issuer),
 	)
 	if err != nil {

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -15,23 +15,6 @@ import (
 	"github.com/ggoodman/mcp-server-go/streaminghttp"
 )
 
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
-var (
-	// MCP_PUBLIC_ENDPOINT should be the externally visible base URL of your server
-	// (used as the expected audience for access tokens). Example: https://mcp.example.com
-	publicEndpoint = envOr("MCP_PUBLIC_ENDPOINT", "http://127.0.0.1:8080/mcp")
-
-	// OIDC_ISSUER should be your OAuth2/OIDC issuer URL. For local/dev, point this
-	// to a local IdP or mock OIDC provider if you have one running.
-	issuer = envOr("OIDC_ISSUER", "http://127.0.0.1:8081/")
-)
-
 type TranslateArgs struct {
 	Text string `json:"text" jsonschema:"minLength=1,description=Text to translate"`
 	To   string `json:"to"   jsonschema:"enum=en,enum=fr,enum=es,description=Target language (ISO 639-1)"`
@@ -40,28 +23,25 @@ type TranslateArgs struct {
 func main() {
 	ctx := context.Background()
 
+	publicEndpoint := os.Getenv("MCP_PUBLIC_ENDPOINT") // e.g. https://mcp.example.com/mcp
+	issuer := os.Getenv("OIDC_ISSUER")                 // your OAuth/OIDC issuer URL
+
 	// 1) Session host for horizontal scale (Redis)
-	host, err := redishost.New(envOr("REDIS_ADDR", "127.0.0.1:6379"))
+	host, err := redishost.New(os.Getenv("REDIS_ADDR"))
 	if err != nil {
 		panic(err)
 	}
 	defer host.Close()
 
-	// 2) Tools (auto-derived JSON Schema; strict by default)
+	// 2) Typed tool with strict input schema by default
 	translate := mcpservice.NewTool[TranslateArgs](
 		"translate",
 		func(ctx context.Context, _ sessions.Session, w mcpservice.ToolResponseWriter, r *mcpservice.ToolRequest[TranslateArgs]) error {
 			a := r.Args()
-			if a.Text == "" {
-				w.SetError(true)
-				_ = w.AppendText("text is required")
-				return nil
-			}
 			_ = w.AppendText("Translated to " + a.To + ": " + a.Text)
 			return nil
 		},
 		mcpservice.WithToolDescription("Translate text to a target language."),
-		// mcpservice.WithToolAllowAdditionalProperties(true), // opt-in to unknown fields
 	)
 	tools := mcpservice.NewStaticTools(translate)
 
@@ -71,23 +51,21 @@ func main() {
 		mcpservice.WithToolsOptions(mcpservice.WithStaticToolsContainer(tools)),
 	)
 
-	// 4) Drop-in OAuth2/OIDC JWT access token auth (RFC 9068): discovery + JWKS
+	// 4) OAuth2/OIDC JWT access token validation (RFC 9068)
 	authenticator, err := auth.NewFromDiscovery(
 		ctx,
 		issuer,
-		auth.WithExpectedAudience(publicEndpoint),
+		auth.WithExpectedAudience(publicEndpoint), // audience check (use your public MCP endpoint)
 		auth.WithLeeway(2*time.Minute),
-		// auth.WithRequiredScopes("mcp:read","mcp:write"), // optional
-		// auth.WithAllowedAlgs("RS256","ES256"),          // optional
 	)
 	if err != nil {
 		panic(err)
 	}
 
-	// 5) Build handler
+	// 5) Drop-in handler
 	h, err := streaminghttp.New(
 		ctx,
-		publicEndpoint, // externally visible URL
+		publicEndpoint,
 		host,
 		server,
 		authenticator,


### PR DESCRIPTION
Enhance the encoding of messages in SSE, streamline the logging setup, and clean up the README example for better clarity and usability.