### PR TITLE
Refactor tests for context-based cancellation and timeout handling

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run unit tests
         run: |
           set -euo pipefail
-          go test ./... -v -count=1 -race -coverprofile=coverage.out -covermode=atomic
+          go test ./... -v -count=1 -race -coverprofile=coverage.out -covermode=atomic -timeout=3m
 
       - name: Upload coverage artifact
         if: always()

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run unit tests
         run: |
           set -euo pipefail
-          go test ./... -v -count=1 -race -coverprofile=coverage.out -covermode=atomic -timeout=3m
+          go test ./... -v -count=1 -race -coverprofile=coverage.out -covermode=atomic -timeout=60s
 
       - name: Upload coverage artifact
         if: always()

--- a/stdio/handler_test.go
+++ b/stdio/handler_test.go
@@ -485,8 +485,8 @@ func TestCancellation_ToolsCall(t *testing.T) {
 
 	select {
 	case <-cancelled:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("tool context was not cancelled")
+	case <-t.Context().Done():
+		t.Fatalf("tool context was not cancelled: %v", t.Context().Err())
 	}
 
 	res, err := th.expectResponse(time.Second)

--- a/streaminghttp/handler_test.go
+++ b/streaminghttp/handler_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
@@ -439,8 +438,8 @@ func TestMultiInstance(t *testing.T) {
 			if msg.Method != string(mcp.ResourcesListChangedNotificationMethod) {
 				t.Fatalf("unexpected method: want %q got %q", mcp.ResourcesListChangedNotificationMethod, msg.Method)
 			}
-		case <-time.After(3 * time.Second):
-			t.Fatalf("timed out waiting for list_changed notification")
+		case <-t.Context().Done():
+			t.Fatalf("context done: %v", t.Context().Err())
 		}
 	})
 
@@ -515,8 +514,8 @@ func TestMultiInstance(t *testing.T) {
 			if msg.Method != string(mcp.ToolsListChangedNotificationMethod) {
 				t.Fatalf("unexpected method: want %q got %q", mcp.ToolsListChangedNotificationMethod, msg.Method)
 			}
-		case <-time.After(3 * time.Second):
-			t.Fatalf("timed out waiting for tools list_changed notification")
+		case <-t.Context().Done():
+			t.Fatalf("context done: %v", t.Context().Err())
 		}
 	})
 
@@ -580,8 +579,8 @@ func TestMultiInstance(t *testing.T) {
 			if msg.Method != string(mcp.PromptsListChangedNotificationMethod) {
 				t.Fatalf("unexpected method: want %q got %q", mcp.PromptsListChangedNotificationMethod, msg.Method)
 			}
-		case <-time.After(3 * time.Second):
-			t.Fatalf("timed out waiting for prompts list_changed notification")
+		case <-t.Context().Done():
+			t.Fatalf("context done: %v", t.Context().Err())
 		}
 	})
 

--- a/tests/resources_subscribe_e2e_test.go
+++ b/tests/resources_subscribe_e2e_test.go
@@ -1,14 +1,14 @@
 package tests
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/ggoodman/mcp-server-go/auth"
 	"github.com/ggoodman/mcp-server-go/mcp"
@@ -153,33 +153,22 @@ func TestResources_SubscribeUpdated_Unsubscribe_E2E(t *testing.T) {
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
-	_ = subResp.Body.Close()
+	// Barrier: read entire response body to ensure server processed subscription before mutation
+	respBytes, _ := io.ReadAll(subResp.Body)
+	subResp.Body.Close()
+	if !bytes.Contains(respBytes, []byte(`"id":"2"`)) {
+		// Not strictly required but good sanity check
+		t.Fatalf("unexpected subscribe response: %s", string(respBytes))
+	}
 
 	// 4) Trigger an update via ReplaceAllContents (which marks updated on res://x)
 	static.ReplaceAllContents(ctx, map[string][]mcp.ResourceContents{"res://x": {{URI: "res://x", Text: "v2"}}})
 
-	// 5) Expect a notifications/resources/updated on SSE
-	scanner := bufio.NewScanner(getResp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-		payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
-		var m map[string]any
-		if err := json.Unmarshal([]byte(payload), &m); err != nil {
-			continue
-		}
-		if method, _ := m["method"].(string); method == string(mcp.ResourcesUpdatedNotificationMethod) {
-			// proceed to unsubscribe phase
-			goto afterUpdated
-		}
+	// 5) Expect a notifications/resources/updated on SSE with bounded wait via helper
+	if err := waitForNotification(t.Context(), getResp.Body, string(mcp.ResourcesUpdatedNotificationMethod), 8*time.Second); err != nil {
+		getResp.Body.Close()
+		t.Fatalf("waiting for resources/updated: %v", err)
 	}
-	if err := scanner.Err(); err != nil {
-		t.Fatalf("scanner error scanning GET /mcp response: %v", err)
-	}
-afterUpdated:
 
 	// 6) Unsubscribe via POST JSON-RPC; do not assert immediate quiescence (eventual semantics)
 	unsubBody := map[string]any{

--- a/tests/resources_subscribe_multinode_e2e_test.go
+++ b/tests/resources_subscribe_multinode_e2e_test.go
@@ -246,16 +246,11 @@ func readOneSSEResponse(ctx context.Context, body io.ReadCloser) error {
 	defer body.Close()
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for {
+	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-		}
-		if !scanner.Scan() {
-			// small yield
-			time.Sleep(5 * time.Millisecond)
-			continue
 		}
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data: ") {
@@ -271,4 +266,8 @@ func readOneSSEResponse(ctx context.Context, body io.ReadCloser) error {
 			return nil
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return io.EOF
 }

--- a/tests/resources_subscribe_multinode_e2e_test.go
+++ b/tests/resources_subscribe_multinode_e2e_test.go
@@ -143,8 +143,8 @@ func TestResources_SubscribeUpdated_MultiNode_UnsubscribeFanout(t *testing.T) {
 	case e := <-errCh:
 		t.Fatalf("GET B: %v", e)
 	case getResp = <-respCh:
-	case <-time.After(3 * time.Second):
-		t.Fatalf("timeout waiting for GET headers on B")
+	case <-t.Context().Done():
+		t.Fatalf("context done waiting for GET headers on B: %v", t.Context().Err())
 	}
 	if getResp.StatusCode != http.StatusOK {
 		t.Fatalf("GET B status: %d", getResp.StatusCode)
@@ -246,14 +246,10 @@ func readOneSSEResponse(ctx context.Context, body io.ReadCloser) error {
 	defer body.Close()
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	timer := time.NewTimer(2 * time.Second)
-	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-timer.C:
-			return fmt.Errorf("timeout waiting for SSE response")
 		default:
 		}
 		if !scanner.Scan() {

--- a/tests/session_delete_e2e_test.go
+++ b/tests/session_delete_e2e_test.go
@@ -118,8 +118,8 @@ func TestDeleteSession_ClosesStreamsAndRevokes(t *testing.T) {
 	select {
 	case <-scanDone:
 		// ok
-	case <-time.After(2 * time.Second):
-		t.Fatalf("GET stream did not close after delete")
+	case <-t.Context().Done():
+		t.Fatalf("context done waiting for GET stream to close after delete: %v", t.Context().Err())
 	}
 
 	// Subsequent POST with same session should now fail with 404

--- a/tests/session_lifecycle_e2e_test.go
+++ b/tests/session_lifecycle_e2e_test.go
@@ -112,8 +112,8 @@ func TestSessionLifecycle_GetStreamBoundToRequest(t *testing.T) {
 	select {
 	case <-done:
 		// ok closed
-	case <-time.After(2 * time.Second):
-		t.Fatalf("GET stream did not close after request cancel")
+	case <-t.Context().Done():
+		t.Fatalf("context done waiting for GET stream close after request cancel: %v", t.Context().Err())
 	}
 }
 
@@ -206,7 +206,7 @@ func TestSessionLifecycle_PostBoundToRequest_WriteFallback(t *testing.T) {
 	select {
 	case <-done:
 		// success: handler returned promptly; underlying fallbacks handled any pending writes
-	case <-time.After(2 * time.Second):
-		t.Fatalf("POST did not finish promptly after cancel")
+	case <-t.Context().Done():
+		t.Fatalf("context done waiting for POST to finish after cancel: %v", t.Context().Err())
 	}
 }

--- a/tests/sse_test_helper.go
+++ b/tests/sse_test_helper.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// waitForNotification scans an SSE stream (lines beginning with "data: ") until it
+// sees a JSON-RPC notification whose "method" field matches target. It enforces a
+// bounded timeout independent of the caller stream lifetime. Returns an error on
+// timeout, stream error, EOF before match, or context cancellation.
+func waitForNotification(parent context.Context, r io.ReadCloser, target string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return contextError(ctx, target)
+		default:
+		}
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		var m map[string]any
+		if err := json.Unmarshal([]byte(payload), &m); err != nil {
+			continue
+		}
+		if method, _ := m["method"].(string); method == target {
+			return nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan error before seeing %s: %w", target, err)
+	}
+	return fmt.Errorf("stream closed before seeing %s", target)
+}
+
+func contextError(ctx context.Context, target string) error {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("timeout waiting for %s", target)
+	}
+	return fmt.Errorf("context canceled waiting for %s: %v", target, ctx.Err())
+}


### PR DESCRIPTION
Update tests to utilize context for managing cancellation and timeout, improving reliability and clarity in error reporting.