### PR TITLE
Add documentation for new packages and update existing package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,412 +1,391 @@
-# MCP Streaming HTTP for Go
+<div align="center">
 
-Drop-in `http.Handler` for the Model Context Protocol (MCP) Streaming HTTP transport — production-minded, horizontally scalable, and designed for both simple and complex servers.
+# mcp-server-go
 
-- Implements the MCP streaming HTTP transport with Server-Sent Events (SSE)
-- First-class authorization and session lifecycle handling
-- Horizontal scale via a pluggable session host (memory or Redis)
-- Static and dynamic capabilities for tools and resources
-- Elicitation helpers: reflection-based and builder DSL for structured user input mid-flow
+<strong>Build Model Context Protocol servers that scale from a 20‑line stdio prototype to a horizontally scaled, OIDC‑protected streaming HTTP deployment — without rewriting business logic.</strong>
 
-## Why this library
+<p>
+	<a href="https://pkg.go.dev/github.com/ggoodman/mcp-server-go"><img alt="Go Reference" src="https://pkg.go.dev/badge/github.com/ggoodman/mcp-server-go.svg" /></a>
+	<a href="https://goreportcard.com/report/github.com/ggoodman/mcp-server-go"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/ggoodman/mcp-server-go" /></a>
+	<a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-green.svg" /></a>
+	<a href="https://github.com/ggoodman/mcp-server-go/actions/workflows/ci-test.yml"><img alt="CI - Test" src="https://github.com/ggoodman/mcp-server-go/actions/workflows/ci-test.yml/badge.svg?branch=main" /></a>
+</p>
 
-1. Horizontal scalability
+</div>
 
-   - Multiple instances can serve the same MCP endpoint and coordinate safely.
-   - Per-session ordered messaging with resume using `Last-Event-ID`.
-   - Pluggable cross-instance coordination via `sessions.SessionHost`.
-     - In-memory host for single-process or tests: `sessions/memoryhost`.
-     - Redis-backed host for multi-instance deployments: `sessions/redishost`.
+---
 
-2. Authorization and session management
+## Install / Import
 
-   - Treats auth and sessions as first-class production concerns.
-   - Out-of-the-box JWT access-token validation (RFC 9068) via OIDC discovery.
-   - Protected Resource Metadata and Authorization Server Metadata endpoints are served for discovery. See `/.well-known/oauth-protected-resource/` and `/.well-known/oauth-authorization-server`.
-   - Clean, minimal `auth.Authenticator` interface if you need custom logic.
+Go module: `github.com/ggoodman/mcp-server-go`
 
-3. Dynamic capabilities
-
-   - Don’t assume your resources or tools are static. Implement dynamic listings and behaviors that pull from databases, APIs, or filesystems.
-   - Prefer static containers when that’s simpler — you still get listChanged notifications and strict input schemas.
-   - Swap static for dynamic later without rewriting your server.
-
-4. Easy adoption, long-term power
-   - Layered API: start with the drop-in handler, grow into custom capabilities.
-   - Pragmatic defaults; minimal opinions. Security and isolation are non-negotiable.
-   - Designed around the hard cases first so simple cases stay simple.
-  - Progressive elicitation tooling: start with struct reflection, graduate to a fluent builder when you need dynamic or programmatic schemas.
-
-## Install
+Add to your project:
 
 ```bash
-go get github.com/ggoodman/mcp-server-go
+go get github.com/ggoodman/mcp-server-go@latest
 ```
 
-## Quick start (prod-friendly with OIDC)
+Browse documentation: https://pkg.go.dev/github.com/ggoodman/mcp-server-go
 
-This minimal server exposes a typed tool using the writer-based API, validates bearer tokens discovered from your issuer, and is horizontally scalable with Redis.
+Minimum Go version: as declared in `go.mod` (currently 1.24). The module follows standard Go module semantic import versioning (no v2 path yet).
+
+---
+
+## TL;DR Quickstart (stdio CLI)
+
+Below is a tiny CLI MCP server exposing a single structured tool that reverses user input and emits both plain text and structured output. Run it under any MCP client that speaks stdio.
 
 ```go
 package main
 
 import (
-    "context"
-    "log/slog"
-    "net/http"
-    "os"
-    "time"
+	"context"
+	"log"
+	"os"
 
-    "github.com/ggoodman/mcp-server-go/auth"
-    "github.com/ggoodman/mcp-server-go/mcp"
-    "github.com/ggoodman/mcp-server-go/mcpservice"
-    "github.com/ggoodman/mcp-server-go/sessions"
-    "github.com/ggoodman/mcp-server-go/sessions/redishost"
-    "github.com/ggoodman/mcp-server-go/streaminghttp"
+	"github.com/ggoodman/mcp-server-go/mcp"
+	"github.com/ggoodman/mcp-server-go/mcpservice"
+	"github.com/ggoodman/mcp-server-go/stdio"
 )
 
-type TranslateArgs struct {
-    Text string `json:"text" jsonschema:"minLength=1,description=Text to translate"`
-    To   string `json:"to"   jsonschema:"enum=en|fr|es,description=Target language (ISO 639-1)"`
+type ReverseArgs struct {
+	Text string `json:"text"`
+}
+
+type ReverseOut struct {
+	Reversed string `json:"reversed"`
+	Length   int    `json:"length"`
 }
 
 func main() {
-    ctx := context.Background()
+	// Define a typed tool in one go (input + output schemas are reflected).
+	reverseTool := mcpservice.NewToolWithOutput[ReverseArgs, ReverseOut](
+		"reverse", // tool name
+		func(ctx context.Context, _ mcpservice.ToolResponseWriterTyped[ReverseOut], w mcpservice.ToolResponseWriterTyped[ReverseOut], r *mcpservice.ToolRequest[ReverseArgs]) error {
+			in := r.Args().Text
+			rs := []rune(in)
+			for i, j := 0, len(rs)-1; i < j; i, j = i+1, j-1 {
+				rs[i], rs[j] = rs[j], rs[i]
+			}
+			out := string(rs)
+			_ = w.AppendText("reversed: " + out) // plain content block
+			w.SetStructured(ReverseOut{Reversed: out, Length: len(rs)})
+			return nil
+		},
+		mcpservice.WithToolDescription("Reverse a string (demo)"),
+	)
 
-    publicEndpoint := os.Getenv("MCP_PUBLIC_ENDPOINT") // e.g. https://mcp.example.com/mcp
-    issuer := os.Getenv("OIDC_ISSUER")                 // your OAuth/OIDC issuer URL
+	tools := mcpservice.NewToolsContainer(reverseTool)
 
-    // 1) Session host for horizontal scale (Redis)
-    host, err := redishost.New(os.Getenv("REDIS_ADDR"))
-    if err != nil {
-        panic(err)
-    }
-    defer host.Close()
+	server := mcpservice.NewServer(
+		mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "reverse-cli", Version: "0.0.1"}),
+		mcpservice.WithToolsCapability(tools),
+	)
 
-    // 2) Typed tool with strict input schema by default
-    translate := mcpservice.NewTool[TranslateArgs](
-        "translate",
-        func(ctx context.Context, _ sessions.Session, w mcpservice.ToolResponseWriter, r *mcpservice.ToolRequest[TranslateArgs]) error {
-            a := r.Args()
-            _ = w.AppendText("Translated to " + a.To + ": " + a.Text)
-            return nil
-        },
-        mcpservice.WithToolDescription("Translate text to a target language."),
-    )
-    tools := mcpservice.NewToolsContainer(translate)
-
-    // 3) Server capabilities
-    server := mcpservice.NewServer(
-        mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-mcp", Version: "1.0.0"}),
-        mcpservice.WithToolsCapability(tools),
-    )
-
-    // 4) OAuth2/OIDC JWT access token validation (RFC 9068)
-    authenticator, err := auth.NewFromDiscovery(
-        ctx,
-        issuer,
-        auth.WithExpectedAudience(publicEndpoint), // audience check (use your public MCP endpoint)
-        auth.WithLeeway(2*time.Minute),
-    )
-    if err != nil {
-        panic(err)
-    }
-
-    log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
-    // 5) Drop-in handler
-    h, err := streaminghttp.New(
-        ctx,
-        publicEndpoint,
-        host,
-        server,
-        authenticator,
-        streaminghttp.WithServerName("My MCP Server"),
-        streaminghttp.WithLogger(log),
-        streaminghttp.WithAuthorizationServerDiscovery(issuer),
-    )
-    if err != nil {
-        panic(err)
-    }
-
-    // 6) Serve
-    http.ListenAndServe("127.0.0.1:8080", h)
+	// Stdio handler spins up an in‑memory SessionHost automatically.
+	h := stdio.NewHandler(server)
+	if err := h.Serve(context.Background()); err != nil {
+		log.Println("server exited:", err)
+		os.Exit(1)
+	}
 }
 ```
 
-See a runnable variant in `examples/readme/main.go`.
-
-## Quick start (local dev, no IdP)
-
-For quick experiments you can plug a minimal authenticator that accepts a fixed token. Do not use this in production.
+Upgrade path: swap the transport + host; your `server` stays the same.
 
 ```go
-type staticTokenAuth struct{ token string }
-
-type devUser struct{}
-func (devUser) UserID() string       { return "dev" }
-func (devUser) Claims(ref any) error { return nil }
-
-func (a staticTokenAuth) CheckAuthentication(ctx context.Context, tok string) (auth.UserInfo, error) {
-    if tok == "Bearer "+a.token || tok == a.token { // accept raw or header value
-        return devUser{}, nil
-    }
-    return nil, auth.ErrUnauthorized
-}
-
-// ... pass staticTokenAuth{token: "dev-token"} to streaminghttp.New(...)
-// Then call your server with Authorization: Bearer dev-token
+// (Sketch – not a full program)
+host := redishost.New(redisClient) // or your implementation of sessions.SessionHost
+authn, _ := auth.NewFromDiscovery(ctx, issuerURL, auth.WithExpectedAudience(publicURL))
+httpHandler, _ := streaminghttp.New(ctx, publicURL, host, server, authn,
+	streaminghttp.WithAuthorizationServerDiscovery(issuerURL),
+	streaminghttp.WithServerName("reverse-prod"),
+)
+http.Handle("/mcp", httpHandler)
 ```
 
-## Horizontal scale in one line (Redis)
+---
+
+## Capability Model (Server Side)
+
+At initialization the client sends its `ClientCapabilities`; the server responds with `ServerCapabilities`. Each negotiated capability unlocks a method set (see `mcp/messages.go`). Server implementations choose between:
+
+1. **Containers (static sets)** – simple, mutation helpers, built‑in pagination and change notifications.
+2. **Callbacks / Providers (dynamic)** – per session logic via option providers (`WithToolsProvider`, etc.).
+
+### Summary Table
+
+| Domain | Methods (list/read/call) | Change Notifications | Container Helper | Dynamic Hook |
+|--------|--------------------------|----------------------|------------------|--------------|
+| Tools | `tools/list`, `tools/call` | `notifications/tools/list_changed` | `NewToolsContainer` + `NewTool*` | `WithToolsProvider` |
+| Resources | `resources/list`, `resources/read`, templates | `notifications/resources/list_changed`, `notifications/resources/updated` | `NewResourcesContainer` | `WithResourcesProvider` |
+| Prompts | `prompts/list`, `prompts/get` | `notifications/prompts/list_changed` | (inline: build your own) | `WithPromptsProvider` |
+| Logging | `logging/setLevel` | `notifications/message` | (implement interface) | `WithLoggingProvider` |
+| Completions | `completion/complete` | — | (implement interface) | `WithCompletionsProvider` |
+| Sampling | `sampling/createMessage` | — | (implement using `mcp/sampling` helpers) | — |
+| Elicitation | `elicitation/create` | — | Use `elicitation.Builder` | — |
+| Roots | `roots/list` | `notifications/roots/list_changed` | (implement interface) | (future) |
+
+### Tools via Container
 
 ```go
-host, _ := redishost.New("127.0.0.1:6379", redishost.WithKeyPrefix("mcp:sessions:"))
-defer host.Close()
+tools := mcpservice.NewToolsContainer(
+	mcpservice.NewTool[MyArgs]("do_stuff", func(ctx context.Context, s sessions.Session, w mcpservice.ToolResponseWriter, r *mcpservice.ToolRequest[MyArgs]) error {
+		_ = w.AppendText("done")
+		return nil
+	}, mcpservice.WithToolDescription("Does stuff")),
+)
+server := mcpservice.NewServer(mcpservice.WithToolsCapability(tools))
 ```
 
-- Ordered per-session message delivery with resume from `Last-Event-ID`.
-- Cross-instance server-internal events for coordination: ordered, future-only
-    fan-out per (session, topic). All current subscribers observe every event
-    published after they subscribe (at-least-once). Minimal retention; no replay.
-- Epoch-based invalidation helpers and revocation markers.
-
-For single-process dev and tests, use the in-memory host:
-
-```go
-host := memoryhost.New()
-```
-
-## Authorization and discovery
-
-When you enable discovery with `WithAuthorizationServerDiscovery(issuer)`, the handler:
-
-- Validates tokens using JWKS from your issuer (via `auth.NewFromDiscovery`).
-- Serves Protected Resource Metadata at `/.well-known/oauth-protected-resource/`.
-- Mirrors Authorization Server Metadata at `/.well-known/oauth-authorization-server`.
-- Responds to unauthorized requests with a standards-compliant `WWW-Authenticate` header that points at the resource metadata.
-
-See the spec documents under `specs/` for details.
-
-## Dynamic capabilities (and static containers)
-
-Prefer dynamic? Implement per-session providers and callbacks:
+### Tools Dynamically (Per Session)
 
 ```go
 server := mcpservice.NewServer(
-    // Dynamic tools (function-backed)
-    mcpservice.WithToolsCapability(mcpservice.NewDynamicTools(
-        mcpservice.WithToolsListFn(func(ctx context.Context, s sessions.Session, cur *string) (mcpservice.Page[mcp.Tool], error) {
-            return mcpservice.NewPage([]mcp.Tool{{Name: "dbTool", InputSchema: mcp.ToolInputSchema{Type: "object"}}}), nil
-        }),
-        mcpservice.WithToolsCallFn(func(ctx context.Context, s sessions.Session, req *mcp.CallToolRequestReceived) (*mcp.CallToolResult, error) {
-            return mcpservice.TextResult("ok"), nil
-        }),
-    )),
-    // Dynamic resources
-    mcpservice.WithResourcesCapability(mcpservice.NewDynamicResources(
-        mcpservice.WithResourcesListFunc(func(ctx context.Context, s sessions.Session, cur *string) (mcpservice.Page[mcp.Resource], error) {
-            return mcpservice.NewPage([]mcp.Resource{{URI: "res://1", Name: "R1"}}), nil
-        }),
-        mcpservice.WithResourcesReadFunc(func(ctx context.Context, s sessions.Session, uri string) ([]mcp.ResourceContents, error) {
-            return []mcp.ResourceContents{{URI: uri, MimeType: "text/plain", Text: "hello"}}, nil
-        }),
-    )),
+	mcpservice.WithToolsProvider(func(ctx context.Context, sess sessions.Session) (mcpservice.ToolsCapability, bool, error) {
+		if sess.UserID() == "restricted" { return nil, false, nil }
+		tc := mcpservice.NewToolsContainer(/* build based on session */)
+		return tc, true, nil
+	}),
 )
 ```
 
-Prefer static? Use the containers and still get listChanged and subscriptions:
+---
+
+## Session-Level Capabilities (Client → Server negotiated)
+
+After initialization you work with a `sessions.Session` value that exposes optional per-session capabilities negotiated during the handshake. These sit alongside the server capability interfaces and let you bridge user workflows that require *client cooperation* (sampling, roots, elicitation) while keeping domain logic cohesive.
+
+`Session` (excerpt):
 
 ```go
-sr := mcpservice.NewResourcesContainer(nil, nil, nil)
+type Session interface {
+	SessionID() string
+	UserID() string
+	ProtocolVersion() string
 
-type HelloArgs struct {
-    Name string `json:"name"`
+	GetSamplingCapability() (cap SamplingCapability, ok bool)
+	GetRootsCapability() (cap RootsCapability, ok bool)
+	GetElicitationCapability() (cap ElicitationCapability, ok bool)
 }
-
-st := mcpservice.NewToolsContainer(
-    mcpservice.NewTool[HelloArgs](
-        "hello",
-        func(ctx context.Context, _ sessions.Session, w mcpservice.ToolResponseWriter, r *mcpservice.ToolRequest[HelloArgs]) error {
-            _ = w.AppendText("hi, " + r.Args().Name)
-            return nil
-        },
-    ),
-)
-server := mcpservice.NewServer(
-    mcpservice.WithResourcesCapability(sr),
-    mcpservice.WithToolsCapability(st),
-)
 ```
 
-## Examples and tests
+Pattern: fetch capability → if present call → honor context cancellation.
 
-- `examples/readme/` — end-to-end server that matches the Quick Start.
-- `examples/echo/` — a simple echo tool server.
-- `examples/resources_*` — static and filesystem-backed resources.
-- See `tests/` for protocol-level and e2e tests that exercise sessions, listChanged, and multi-instance delivery.
+### SamplingCapability
 
-## Compatibility
+Use when you need the client (or host application) to produce a model-generated message given prior exchange context.
 
-- MCP spec revision targeted: see `docs/mcp.md` (streaming HTTP transport; JSON-RPC batching is intentionally not used).
-- Go version: see `go.mod` (currently `go 1.24`).
+```go
+if samp, ok := sess.GetSamplingCapability(); ok {
+	req := sampling.NewCreateMessage([]mcp.SamplingMessage{
+		{Role: mcp.RoleUser, Content: mcp.ContentBlock{Type: mcp.ContentTypeText, Text: "Summarize current plan"}},
+	}, sampling.WithSystemPrompt("Be concise"), sampling.WithMaxTokens(256))
+	if err := sampling.ValidateCreateMessage(req); err != nil { return err }
+	res, err := samp.CreateMessage(ctx, req)
+	if err != nil { return err }
+	log.Printf("model=%s reply=%s", res.Model, res.Content.Text)
+}
+```
 
-## Security notes
+Guidelines:
+* Keep requests minimal; let client/host append its own context.
+* Validate with `sampling.ValidateCreateMessage` in development to catch mistakes early.
+* Treat absence (`ok == false`) as “feature not negotiated” and degrade gracefully.
 
-- Bearer token validation follows RFC 9068 with OIDC discovery (JWKS).
-- Unauthorized requests receive standards-compliant `WWW-Authenticate` with pointers for discovery.
-- The library is designed to avoid cross-user contamination across sessions and instances.
+### RootsCapability
+
+Represents a logical workspace hierarchy (e.g. project roots / mount points) the client can surface. Use for enumerating base folders before listing resources from another subsystem or external index.
+
+```go
+if rootsCap, ok := sess.GetRootsCapability(); ok {
+	roots, err := rootsCap.ListRoots(ctx)
+	if err != nil { return err }
+	for _, r := range roots.Roots {
+		log.Printf("root: %s (%s)", r.URI, r.Name)
+	}
+	// Optional: register change listener if supported
+	_, _ = rootsCap.RegisterRootsListChangedListener(ctx, func(lctx context.Context) error {
+		updated, err := rootsCap.ListRoots(lctx)
+		if err == nil {
+			log.Printf("roots changed: %d", len(updated.Roots))
+		}
+		return nil // keep listening
+	})
+}
+```
+
+Listener semantics: returning an error stops delivery; returning nil keeps the registration active (implementation may re-call on change events).
+
+### ElicitationCapability
+
+Collect structured user input (with validation) mid-flight without inventing ad-hoc tool schemas for every prompt.
+
+```go
+if el, ok := sess.GetElicitationCapability(); ok {
+	type Input struct {
+		Name string `json:"name" jsonschema:"minLength=1,description=Your name"`
+	}
+	var in Input
+	// Bind struct into a decoder
+	dec := elicitation.BindStruct(&in) // (builder constructs schema + decoder)
+	action, err := el.Elicit(ctx, "Who are you?", dec, sessions.WithStrictKeys())
+	if err != nil { return err }
+	if action != sessions.ElicitActionAccept { /* user declined or cancelled */ return nil }
+	log.Printf("user identified as %s", in.Name)
+}
+```
+
+Options:
+* `sessions.WithStrictKeys()` – reject unexpected properties.
+* `sessions.WithRawCapture(&m)` – capture raw map for auditing or secondary parsing.
+
+Best practices:
+* Fail fast on schema reflection errors before issuing Elicit calls.
+* Keep elicitation schemas shallow (current implementation rejects nested objects/arrays for simplicity/performance).
+* Treat non-accept actions as soft negative signals — do not log as errors.
+
+---
+
+### Resources Container Example
+
+```go
+res := []mcp.Resource{{URI: "file:///README.md", Name: "readme"}}
+contents := map[string][]mcp.ResourceContents{
+	"file:///README.md": {{Contents: []mcp.ContentBlock{{Type: "text", Text: "hello"}}}},
+}
+rc := mcpservice.NewResourcesContainer(res, nil, contents)
+server := mcpservice.NewServer(mcpservice.WithResourcesCapability(rc))
+```
+
+Resource subscriptions & change notifications are bridged automatically when the transport and client both advertise support.
+
+### Mixing Static + Dynamic
+
+You can combine containers for straightforward domains and dynamic providers where session‑aware filtering or expensive lazy construction is needed. Each `With*Capability` sets a static implementation; the corresponding `With*Provider` overrides it if both are supplied.
+
+---
+
+## Client Capabilities (What the Server Receives)
+
+Client initialization request (`initialize`) includes:
+
+```jsonc
+{
+	"protocolVersion": "2025-06-18", // example
+	"capabilities": { /* client capability bits */ },
+	"clientInfo": {"name":"my-client","version":"1.2.3"}
+}
+```
+
+Server decides preferred protocol (`GetPreferredProtocolVersion`) and optionally returns human instructions. The negotiated server capabilities then govern which MCP methods are valid for the session. If you omit a capability (e.g. tools) the transport simply rejects those method calls up front — your code never sees them.
+
+### Progress & Cancellation
+
+Long running tool calls can emit `notifications/progress` (server -> client) and clients can cancel by sending `notifications/cancelled`. The engine mediates this for you; just pay attention to `ctx.Done()` inside handlers.
+
+### Sampling & Elicitation Helpers
+
+Package `mcp/sampling` provides ergonomic helpers for building sampling messages; `elicitation` provides a builder for collecting structured values from the client. They layer cleanly atop the same session and transport plumbing.
+
+---
+
+## Pluggable Session Storage (`SessionHost`)
+
+`SessionHost` is the persistence + messaging abstraction the engine uses (see `sessions/host.go`). It unifies:
+
+1. Ordered, resumable per‑session outbound stream (`PublishSession` / `SubscribeSession`).
+2. Internal pub/sub topics (`PublishEvent` / `SubscribeEvents`) for cross‑node coordination.
+3. Session metadata lifecycle (create / mutate / touch / delete).
+4. Per‑session bounded key/value store.
+
+Reference implementations:
+
+| Package | Characteristics | When to Use |
+|---------|-----------------|-------------|
+| `sessions/memoryhost` | In‑memory, ephemeral, zero deps | Tests, prototyping, stdio, single-node |
+| `sessions/redishost`  | Durable metadata + streams via Redis | Streaming HTTP, multi-node, need fan-out |
+
+Implement your own by satisfying `sessions.SessionHost`. Focus areas:
+
+* At‑least‑once delivery for session stream (client handles idempotency).
+* Minimal latency for publish + subscribe paths.
+* Safe concurrent access (multiple engines / transports may share host).
+
+---
+
+## High-Level Architecture & Data Flow
+
+```mermaid
+flowchart LR
+	Client -- JSON-RPC (stdio / SSE over HTTP) --> Transport
+	subgraph ServerProcess
+		Transport --> Engine
+		Engine --> Capabilities[Server Capabilities Impl]
+		Engine --> Host[(SessionHost)]
+		Capabilities <--> Host
+	end
+
+	Host -. horizontal scale .- HostReplica[(SessionHost on another node)]
+```
+
+1. Transport (stdio or streaming HTTP) performs framing + auth (HTTP mode) and session header validation.
+2. Engine owns the session handshake, capability discovery, dispatch, fan‑out of subscription notifications, progress + cancellation bridging.
+3. Capabilities implement domain logic (tools, resources, prompts…). They stay ignorant of transport and persistence details.
+4. `SessionHost` provides ordered event streams + metadata durability; swapping it changes scaling characteristics without touching capability logic.
+
+Key property: A single logical pipeline of JSON‑RPC messages flows through transport → engine → capability and back. Horizontal scaling comes from making the host and engine stateless aside from what is persisted in `SessionHost`.
+
+---
+
+## Scaling Path
+
+| Phase | Transport | Host | Auth | Notes |
+|-------|-----------|------|------|-------|
+| Proto | `stdio` | `memoryhost` | none | 0 infra, fastest iteration |
+| Pilot | streaming HTTP | `memoryhost` (single pod) | OIDC (optional) | Introduce real clients, measure |
+| Scale | streaming HTTP (multi) | `redishost` | OIDC + scopes | Add observability, autoscale |
+| Custom | streaming HTTP | your host | OIDC + custom claims | Special persistence / tenancy |
+
+---
+
+## Design Decisions (Condensed)
+
+* **Capability interfaces** isolate protocol surface; containers reduce boilerplate for static cases.
+* **Functional options** allow mixing static and dynamic providers without config structs.
+* **At‑least‑once delivery** chosen over exactly-once to avoid distributed consensus complexity; handlers must be idempotent.
+* **Separation of concerns:** transport handles framing & auth; engine handles protocol flow; capabilities handle business data; host handles durability & fan-out.
+
+---
+
+## Future Directions (Indicative, Not Promises)
+
+* Structured logging adapter examples.
+* Additional host implementations (SQL / S3 hybrid, memory+lru shard, etc.).
+* Metrics hooks (per method latency, subscription churn).
+* Richer prompt templating helpers.
+
+Contributions welcome — see `CONTRIBUTING.md`.
+
+---
+
+## FAQ (Early)
+
+**Q: Do I need Redis to start?**  No — stdio + memory host gets you running instantly.
+
+**Q: How do I add authentication?** Use `auth.NewFromDiscovery` with `WithExpectedAudience(publicURL)` then pass the authenticator to `streaminghttp.New`.
+
+**Q: How do I emit progress?** The tool writer returned by `NewTool*` supports `_ = w.Progress(fraction)`. Honor context cancellation to be well-behaved.
+
+**Q: Are method names stable?** Protocol revision tags define stability; this SDK tracks the spec revision you compile against.
+
+---
 
 ## License
 
-MIT — see `LICENSE`.
+MIT – see `LICENSE`.
 
-## Ergonomic helpers (optional)
+---
 
-The core `mcp` package exposes only wire-level structs. For less boilerplate you can opt into the helper packages:
+Feedback, missing ergonomics, or sharp edges? Open an issue with a focused description; API changes are still on the table before 1.0.
 
-- `mcp/sampling` – build `CreateMessageRequest` values and message/content blocks.
-- `mcp/elicitation` – build elicitation schemas via a small DSL and validate them.
-
-You can ignore these packages entirely; they never wrap or hide protocol data structures.
-
-### Sampling helpers
-
-Raw (manual struct literals):
-
-```go
-req := &mcp.CreateMessageRequest{
-    Messages: []mcp.SamplingMessage{
-        {Role: mcp.RoleUser, Content: mcp.ContentBlock{Type: mcp.ContentTypeText, Text: "Translate to French: Hello"}},
-    },
-    SystemPrompt: "You translate only.",
-    MaxTokens:    80,
-}
-```
-
-With helpers:
-
-```go
-import "github.com/ggoodman/mcp-server-go/mcp/sampling"
-
-req := sampling.NewCreateMessage(
-    []mcp.SamplingMessage{
-        sampling.UserText("Translate to French: Hello"),
-    },
-    sampling.WithSystemPrompt("You translate only."),
-    sampling.WithMaxTokens(80),
-)
-
-if err := sampling.ValidateCreateMessage(req); err != nil { /* handle */ }
-resp, _ := sp.CreateMessage(ctx, req)
-```
-
-### Elicitation (reflective API)
-
-Elicitation lets the server request structured user input mid-flow. Two authoring modes are provided:
-
-1. Reflection: pass a struct pointer and tags (`json` + `jsonschema`) are inspected to build a flat object schema.
-2. Builder DSL: construct a schema programmatically (useful when shape is not known at compile time) and optionally bind back into a struct.
-
-Supported primitives: `string`, `number`, `integer`, `boolean`, and string enums. No nesting (yet). Optional vs required is determined by pointer-ness (reflection) or `Optional()/Required()` (builder).
-
-Basic reflection example:
-
-```go
-type LanguageChoice struct {
-    Language string `json:"language" jsonschema:"description=Target language,minLength=1"`
-}
-
-el, ok := sess.GetElicitationCapability()
-if ok {
-    var lc LanguageChoice
-    dec, err := elicitation.BindStruct(&lc) // SchemaDecoder bound to &lc
-    if err != nil { /* handle */ }
-    action, err := el.Elicit(ctx, "Which language should I translate to?", dec, sessions.WithMessage("Which language should I translate to?"))
-    if err != nil { /* transport / validation error */ }
-    if action == sessions.ElicitActionAccept {
-        // lc.Language populated
-    }
-}
-```
-
-Builder example with defaults and enum names:
-
-```go
-sch := elicitation.NewBuilder().
-    EnumString("tone", []string{"formal","casual"}, EnumNames("Formal","Casual"), Optional()).
-    String("audience", Optional(), Description("Intended audience"), MinLength(3), DefaultString("general")).
-    Boolean("proofread", Optional(), DefaultBool(true)).
-    MustBuild()
-
-var dst struct {
-    Tone *string
-    Audience *string
-    Proofread *bool
-}
-dec, _ := elicitation.NewBuilder(). // or reuse the builder above to BindStruct
-    EnumString("tone", []string{"formal","casual"}, EnumNames("Formal","Casual"), Optional()).
-    String("audience", Optional()).
-    Boolean("proofread", Optional()).
-    BindStruct(&dst)
-_ = dec.Decode(map[string]any{}, &dst) // applies defaults to optional pointers
-```
-
-Defaults (reflection & builder): optional-only properties may declare a single default (`default=...` tag or `Default*(...)` option). Supported for boolean, string, number, integer; validated against enum and constraints; applied only when the field is absent.
-
-Options:
-
-* `sessions.WithMessage(string)` – prompt shown to the user.
-* `sessions.WithStrictKeys()` – reject unknown keys (default: ignore extras).
-* `sessions.WithRawCapture(&map[string]any{})` – access the raw response map.
-
-Constraints (enforced server-side for now):
-
-* No nested objects / arrays / oneOf / anyOf / refs.
-* Enum only on string fields.
-* Pointer fields are optional; non-pointer fields are required if present in the reflected schema's required set.
-* Numeric min/max derived from jsonschema tags when supported by `invopop/jsonschema`.
-
-### Design goals
-
-1. Pure value builders: never introduce wrapper types.
-2. Everything is additive; raw structs remain first-class.
-3. Minimal API surface: helpers focus on reducing typos and repetition, not inventing new protocol concepts.
-4. Easy escape hatch: you can intermix manual and helper-constructed values freely.
-
-The earlier one-off request-building layer was replaced by the reflection + builder pairing. Both produce canonical, fingerprinted schemas for stable client caching.
-
-## Structured logging (concise)
-
-We use Go's standard `log/slog` with stable, dot-delimited event names. Correlation fields:
-
-| Field       | When present                                   |
-|-------------|-------------------------------------------------|
-| `request_id`| Per inbound HTTP POST / GET stream / stdio req  |
-| `session_id`| After session create / load                     |
-| `user_id`   | After authentication succeeds                   |
-
-Event naming: `<domain>.<action>.<state>` where `state ∈ {start, ok, fail, miss, denied, cancel, end}`.
-
-| Transport | Event(s) | Meaning / Notes | Level |
-|-----------|----------|-----------------|-------|
-| HTTP | `http.post.start` | POST /mcp entry | info |
-| HTTP | `session.create.ok` | New session created | info |
-| HTTP | `session.load.ok` / `session.load.miss` | Load success / not found or unauthorized | info |
-| HTTP | `protocol.version.mismatch` | Client vs session protocol mismatch | warn |
-| HTTP | `rpc.inbound.start` / `rpc.inbound.ok` / `rpc.inbound.fail` | JSON-RPC (request with ID) lifecycle | info / error |
-| HTTP | `notification.inbound.ok` / `notification.inbound.fail` | Notification handling result | info / warn |
-| HTTP | `sse.stream.start` / `sse.stream.end` | GET /mcp SSE lifecycle | info |
-| HTTP | `sse.message.deliver` | Outbound JSON-RPC message delivered on SSE | info |
-| HTTP | `session.delete.ok` / `session.delete.fail` | DELETE /mcp lifecycle | info / error |
-| HTTP | `auth.ok` / `auth.fail` | Authentication result (`fail` is expected denial) | info |
-| stdio | `stdio.serve.start` | stdio loop start | info |
-| stdio | `session.initialize.ok` | initialize handshake succeeded | info |
-| stdio | `protocol.initialize.expected` | Non-initialize message before handshake | warn |
-| stdio | `json.decode.fail` | Malformed inbound line | warn |
-| stdio | `rpc.inbound.start` / `rpc.inbound.ok` / `rpc.inbound.fail` | Request lifecycle | info / error |
-| stdio | `stdio.eof` | Graceful EOF shutdown | info |
-
-Level guidelines: Info = normal lifecycle & auth denials; Warn = client/protocol misuse or malformed input; Error = internal failures / invariants.
-
-Provide a custom logger with `streaminghttp.WithLogger(*slog.Logger)` (or analogous options elsewhere); only `Info/Warn/Error` are invoked.

--- a/auth/doc.go
+++ b/auth/doc.go
@@ -1,0 +1,52 @@
+// Package auth provides pluggable authentication primitives used by the
+// streaming HTTP transport. It focuses on bearer token (JWT) verification
+// for MCP servers that delegate authorization to an external OAuth 2.0 / OIDC
+// authorization server.
+//
+// The public surface intentionally stays small: an Authenticator validates an
+// incoming bearer token string and returns a UserInfo (or an error). The
+// transport is responsible for extracting the token from the HTTP request and
+// mapping sentinel errors into protocol-specific challenges.
+//
+// # Access Token Authentication
+//
+// NewFromDiscovery constructs an Authenticator that validates RFC 9068
+// access tokens using OpenID Connect discovery to obtain the issuer's JWKS
+// and metadata. Callers configure validation requirements via functional
+// options (expected audience, required scopes, leeway, allowed algorithms).
+//
+// Example:
+//
+//	ctx := context.Background()
+//	authn, err := auth.NewFromDiscovery(ctx, "https://issuer.example",
+//	    auth.WithExpectedAudience("https://mcp.example/api"),
+//	    auth.WithRequiredScopes("mcp:read", "mcp:write"),
+//	)
+//	if err != nil { log.Fatal(err) }
+//
+//	// Later inside request handling (pseudocode):
+//	ui, err := authn.CheckAuthentication(r.Context(), bearerToken)
+//	if errors.Is(err, auth.ErrUnauthorized) { /* map to 401 challenge */ }
+//	if errors.Is(err, auth.ErrInsufficientScope) { /* map to insufficient scope */ }
+//	userID := ui.UserID()
+//
+// # Scopes
+//
+// WithRequiredScopes enforces that all provided scopes are present in the
+// token's space-delimited scope claim; WithAnyRequiredScope relaxes this so
+// at least one matches. Only one of these should be used per Authenticator
+// configuration (subsequent calls overwrite scope mode).
+//
+// Algorithms & Clock Skew
+//
+// By default only RS256 is accepted. Use WithAllowedAlgs to broaden the set.
+// WithLeeway adds tolerance for clock skew when validating exp/iat/nbf.
+//
+// # Errors
+//
+// ErrUnauthorized signals the token is invalid (signature, expiry, audience,
+// etc.). ErrInsufficientScope signals successful authentication but missing
+// required scope(s). Additional HTTP challenge detail is surfaced via the
+// internal AuthenticationResult type used by the transport layer; typical
+// library users do not construct those directly.
+package auth

--- a/elicitation/elicitation.go
+++ b/elicitation/elicitation.go
@@ -1,29 +1,3 @@
-// Package elicitation provides building blocks for constructing schemas used in
-// the MCP Elicit request/response flow.
-//
-// Design goals:
-//  1. Keep the *ergonomic* reflection path (give us a struct pointer and we
-//     derive a flat JSON Schema) while allowing more explicit / dynamic paths.
-//  2. Decouple schema construction from value decoding so that callers can
-//     reuse a compiled schema with multiple decode strategies (e.g. applying
-//     defaults, strict business validation, instrumentation, projections).
-//  3. Preserve space for future optimizations (schema fingerprint based caching
-//     / registration) and richer features without locking the public API into
-//     a monolith today.
-//
-// Layering rationale:
-//
-//	SchemaProvider --> describes *what* we will ask the client for.
-//	ValueDecoder   --> describes *how* to take the returned raw object and
-//	                   populate a destination value, enforcing validation rules.
-//	SchemaDecoder  --> simple composite that satisfies both; the most common
-//	                   thing users interact with. Splitting the two lower-level
-//	                   concerns keeps advanced scenarios possible without
-//	                   forcing complexity onto the default path.
-//
-// A server normally just passes a SchemaDecoder to Elicit(). The reflection
-// helper (added separately) returns one. More advanced use cases can build a
-// dynamic schema struct directly and implement a custom ValueDecoder.
 package elicitation
 
 // Schema is an immutable, in-memory representation of a JSON schema fragment

--- a/mcp/doc.go
+++ b/mcp/doc.go
@@ -1,0 +1,60 @@
+// Package mcp contains protocol data types and constants shared across
+// transports and server capability implementations. It mirrors the wire
+// representation specified by the Model Context Protocol while keeping the
+// surface Go-friendly (exported structs with json tags, string constants for
+// method names and enumerations, helper validation functions).
+//
+// The package is intentionally free of transport logic: HTTP streaming,
+// stdio, or any future transports import these types but implement their own
+// framing, authentication and session handling. Likewise higher-level server
+// packages (e.g. mcpservice) construct responses using these concrete types
+// and hand them to the engine for JSON-RPC serialization.
+//
+// # Method Names
+//
+// JSON-RPC method and notification names are enumerated as Method constants
+// (e.g. ToolsListMethod). Using the constants avoids typographical mistakes
+// and ensures a single point of truth if the spec evolves.
+//
+// # Capabilities
+//
+// ClientCapabilities and ServerCapabilities capture negotiated feature sets.
+// They are thin structs shaped to match the JSON spec. Capability advertising
+// happens during initialize/initializeResult exchanges; transports simply
+// marshal these types.
+//
+// # Pagination
+//
+// Many list operations use cursor-based pagination. PaginatedRequest and
+// PaginatedResult are embedded in request / result envelopes to keep the core
+// list types clean while offering forward-compatible metadata via BaseMetadata.
+//
+// # Metadata
+//
+// BaseMetadata allows response producers to attach implementation-defined
+// metadata under the _meta key without inflating every struct with an unused
+// field. Composition (embedding) keeps serialization cost minimal when unset.
+//
+// Example (tool result construction):
+//
+//	res := &mcp.CallToolResult{
+//	    Content: []mcp.ContentBlock{{Type: mcp.ContentTypeText, Text: "hello"}},
+//	}
+//
+// Example (progress notification object):
+//
+//	prog := mcp.ProgressNotificationParams{ProgressToken: "op1", Progress: 42, Total: 100}
+//	// engine layer serializes & dispatches
+//
+// # Logging Levels
+//
+// LoggingLevel values mirror syslog severities defined by the spec. Use
+// IsValidLoggingLevel to validate user-provided values in capability code.
+//
+// # Compatibility
+//
+// The LatestProtocolVersion constant reflects the most recent protocol date
+// the library targets. Transports negotiate versions at runtime; application
+// code can compare a session's negotiated version with this constant to gate
+// optional behaviors.
+package mcp

--- a/mcp/sampling/doc.go
+++ b/mcp/sampling/doc.go
@@ -1,0 +1,28 @@
+// Package sampling provides lightweight helpers for constructing MCP
+// sampling/createMessage requests. It focuses on ergonomics when building
+// chat style message arrays and configuring optional generation parameters.
+//
+// The core wire type lives in package mcp (CreateMessageRequest). This
+// package layers a small builder pattern over it:
+//   - Convenience constructors for single-block user / assistant messages
+//   - Functional options for system prompt, temperature, max tokens, stop sequences
+//   - Validation helper for preflight sanity checks before sending
+//
+// Example:
+//
+//	msgs := []mcp.SamplingMessage{
+//	    sampling.UserText("Summarize this repository"),
+//	}
+//	req := sampling.NewCreateMessage(
+//	    msgs,
+//	    sampling.WithSystemPrompt("You are a terse summarizer."),
+//	    sampling.WithTemperature(0.2),
+//	    sampling.WithMaxTokens(256),
+//	)
+//	if err := sampling.ValidateCreateMessage(req); err != nil { return err }
+//	// send via your session's SamplingCapability
+//
+// The helpers are intentionally minimal; they do not attempt to model provider
+// specific parameters beyond those in the protocol. Applications are free to
+// extend CreateMessageRequest.Metadata for vendor-specific hints.
+package sampling

--- a/mcpservice/doc.go
+++ b/mcpservice/doc.go
@@ -1,56 +1,111 @@
-// Package mcpserver provides building blocks for implementing MCP server
-// capabilities in a composable way. It exposes capability interfaces consumed by
-// the Streaming HTTP handler, plus helpers for static resources, static tools,
-// and change notifications.
+// Package mcpservice provides the public server capability layer for MCP. It
+// defines capability interfaces (tools, resources, prompts, logging,
+// completions) plus composable helpers for building either static (predefined)
+// or dynamic (per-session) implementations. Transports (streaming HTTP, stdio)
+// depend on this package to discover what a server supports for a negotiated
+// session and translate JSON-RPC method calls into interface invocations.
 //
-// Quick start (static):
+// Relationship to Other Packages
 //
-//	notifier := &mcpserver.ChangeNotifier{}
-//	staticRes := mcpserver.NewResourcesContainer(
-//	    []mcp.Resource{{URI: "res://hello.txt", Name: "hello.txt"}},
-//	    nil,
-//	    map[string][]mcp.ResourceContents{
-//	        "res://hello.txt": {{URI: "res://hello.txt", Text: ptr("hello")}},
-//	    },
-//	)
+//	mcp         -> raw protocol types (requests/results, enums)
+//	mcpservice  -> capability interfaces & helpers
+//	sessions    -> session abstraction + host persistence
+//	streaminghttp / stdio -> transport binding using an Engine internally
+//
+// # Capability Discovery
+//
+// The ServerCapabilities interface is the root entry point: transports call
+// getters (e.g. GetToolsCapability) per session to obtain concrete capability
+// values. Each getter returns (cap, ok, err) allowing a server to omit
+// capabilities or fail transiently without forcing a global shape.
+//
+// # Static vs Dynamic Implementations
+//
+// Static helpers (ToolsContainer, ResourcesContainer, PromptsContainer) manage
+// an internal thread-safe set and optionally emit change notifications.
+// Dynamic helpers (NewDynamicTools, NewDynamicResources, NewDynamicPrompts)
+// accept functional options representing custom list/read/call logic; they’re
+// ideal for multi-tenant or data-driven servers.
+//
+// Summary (Capabilities vs Helpers):
+//
+//	Capability   | Static Container          | Dynamic Builder
+//	-------------|---------------------------|-----------------------------
+//	Tools        | ToolsContainer            | NewDynamicTools(...options)
+//	Resources    | ResourcesContainer / FS   | NewDynamicResources(...)
+//	Prompts      | PromptsContainer          | NewDynamicPrompts(...)
+//	Logging      | NewSlogLevelVarLogging    | (implement interface)
+//	Completions  | (implement interface)     | (implement interface)
+//
+// # Pagination
+//
+// All list operations return a Page[T] with an optional NextCursor. Static
+// containers use in-memory slices; dynamic implementations decide their own
+// cursor encoding. A nil cursor requests the first page.
+//
+// # Change Notifications
+//
+// Containers embed a ChangeNotifier and expose it through GetListChangedCapability
+// so transports can advertise listChanged support. Dynamic variants opt-in by
+// providing a ChangeSubscriber via option.
+//
+// # Progress Reporting
+//
+// Long-running tool handlers can retrieve a ProgressReporter (transport bound)
+// from context using ReportProgress helper functions (see progress.go) while
+// streaming partial textual results through ToolResponseWriter.
+//
+// # Examples
+//
+// Static tools + dynamic resources illustrating mixed mode:
+//
+//	// Static echo tool
 //	type EchoArgs struct { Message string `json:"message"` }
-//	staticTools := mcpserver.NewToolsContainer(
-//	    mcpserver.TypedTool[EchoArgs](
+//	tools := mcpservice.NewToolsContainer(
+//	    mcpservice.TypedTool[EchoArgs](
 //	        mcp.Tool{
-//	            Name:        "echo",
-//	            Description: "Echo a message back to the caller",
-//	            InputSchema: mcp.ToolInputSchema{
-//	                Type: "object",
-//	                Properties: map[string]mcp.SchemaProperty{
-//	                    "message": {Type: "string"},
-//	                },
-//	                Required: []string{"message"},
-//	            },
+//	            Name: "echo",
+//	            Description: "Echo a message back",
+//	            InputSchema: mcp.ToolInputSchema{Type: "object", Properties: map[string]mcp.SchemaProperty{
+//	                "message": {Type: "string"},
+//	            }, Required: []string{"message"}},
 //	        },
 //	        func(ctx context.Context, s sessions.Session, a EchoArgs) (*mcp.CallToolResult, error) {
-//	            return mcpserver.TextResult("you said: " + a.Message), nil
+//	            return mcpservice.TextResult(a.Message), nil
 //	        },
 //	    ),
 //	)
 //
-//	srv := mcpserver.NewServer(
-//	    mcpserver.WithServerInfo(mcp.ImplementationInfo{Name: "example", Version: "1.0.0"}),
-//	    mcpserver.WithResourcesCapability(staticRes),
-//	    mcpserver.WithToolsCapability(staticTools),
+//	// Dynamic per-session resources (user-scoped)
+//	dynRes := func(ctx context.Context, s sessions.Session) (mcpservice.ResourcesCapability, bool, error) {
+//	    return mcpservice.NewDynamicResources(
+//	        mcpservice.WithResourcesListFunc(func(ctx context.Context, _ sessions.Session, c *string) (mcpservice.Page[mcp.Resource], error) {
+//	            uri := "res://user/"+s.UserID()+"/profile"
+//	            return mcpservice.NewPage([]mcp.Resource{{URI: uri, Name: "profile"}}), nil
+//	        }),
+//	        mcpservice.WithResourcesReadFunc(func(ctx context.Context, _ sessions.Session, uri string) ([]mcp.ResourceContents, error) {
+//	            if !strings.Contains(uri, s.UserID()) { return nil, fmt.Errorf("not found") }
+//	            return []mcp.ResourceContents{{URI: uri, Text: "dynamic content"}}, nil
+//	        }),
+//	    ), true, nil
+//	}
+//
+//	server := mcpservice.NewServer(
+//	    mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "example", Version: "0.1.0"}),
+//	    mcpservice.WithToolsCapability(tools),
+//	    mcpservice.WithResourcesProvider(dynRes),
 //	)
 //
-// Dynamic per-session capabilities:
+// Implementing a custom capability: write a struct satisfying the interface
+// (e.g. ToolsCapability) and return it from the corresponding getter option.
 //
-//	srv := mcpserver.NewServer(
-//	    mcpserver.WithResourcesProvider(func(ctx context.Context, s sessions.Session) (mcpserver.ResourcesCapability, bool, error) {
-//	        if s.UserID() == "guest" { return nil, false, nil }
-//	        return mcpserver.NewDynamicResources(
-//	            mcpserver.WithResourcesListFunc(func(ctx context.Context, _ sessions.Session, c *string) (mcpserver.Page[mcp.Resource], error) {
-//	                return mcpserver.NewPage([]mcp.Resource{{URI: "res://user/"+s.UserID()+"/profile"}}), nil
-//	            }),
-//	        ), true, nil
-//	    }),
-//	)
+// Error Semantics (selector table):
 //
-// See server.go and capability files for full API details.
+//	Context cancellation / deadline -> return ctx.Err()
+//	Not found                       -> wrap / return descriptive error (transport relays message)
+//	Validation issues               -> return error; transport surfaces JSON-RPC error
+//	Internal unexpected             -> return error; log at call site
+//
+// The package avoids opinionated error types; callers can wrap errors with
+// additional context. Transports treat all non-nil errors as JSON-RPC errors.
 package mcpservice

--- a/sessions/doc.go
+++ b/sessions/doc.go
@@ -1,0 +1,49 @@
+// Package sessions defines the core session abstraction shared by MCP
+// transports and server capability code. A session represents the negotiated
+// protocol version, authenticated principal, and optional capability surface
+// for a connected client. Transports create and persist session metadata via a
+// SessionHost implementation and attach capability handles returned from
+// higher-level server code (mcpservice).
+//
+// Layers & Roles
+//
+//	Transport      -> orchestrates initialize handshake, manages lifetime
+//	SessionHost    -> durability & coordination (ordered client stream + internal events + metadata + KV)
+//	Session object -> per-session view exposed to capability code
+//
+// # Host Interface
+//
+// SessionHost abstracts persistence and ordered fan-out semantics required by
+// streaming transports:
+//   - PublishSession / SubscribeSession : ordered client-visible message log (at-least-once)
+//   - PublishEvent / SubscribeEvents    : server-internal coordination topics
+//   - Metadata CRUD + sliding TTL       : lifecycle & revocation
+//   - Bounded per-session KV            : small auxiliary state
+//
+// Implementations
+//
+//	memoryhost : in-memory reference used for tests / single-process examples
+//	redishost  : Redis Streams backed implementation for horizontal scale and durability
+//
+// # Capabilities
+//
+// A Session may expose optional capability interfaces (sampling, roots,
+// elicitation). Transport / engine layers interrogate these when handling
+// incoming JSON-RPC requests. Absence simply means the server did not elect
+// to provide that surface for the session.
+//
+// # Elicitation Helpers
+//
+// WithStrictKeys and WithRawCapture configure per-call decoding semantics for
+// ElicitationCapability.Elicit. They modify ElicitConfig through functional
+// options; additional options can be added without breaking callers.
+//
+// Example (strict elicitation):
+//
+//	var input struct { Name string `json:"name" jsonschema:"minLength=1"` }
+//	dec, _ := elicitation.BindStruct(&input)
+//	action, err := session.GetElicitationCapability().Elicit(ctx, "Who are you?", dec, sessions.WithStrictKeys())
+//	if err != nil { return err }
+//	if action != sessions.ElicitActionAccept { return }
+//	// use input.Name
+package sessions

--- a/sessions/memoryhost/doc.go
+++ b/sessions/memoryhost/doc.go
@@ -1,0 +1,21 @@
+// Package memoryhost provides an in-memory sessions.SessionHost implementation
+// suitable for tests, development, and single-process servers. All state is
+// ephemeral and discarded on process exit. It implements ordered per-session
+// message streaming, internal topic fan-out, metadata persistence, and small
+// per-session key/value storage using Go data structures guarded by mutexes.
+//
+// Characteristics
+//
+//	Durability        : none (RAM only)
+//	Horizontal scale  : no (process local)
+//	Ordering          : monotonic decimal IDs per session stream
+//	Event delivery    : at-least-once best-effort
+//	Concurrency       : safe (RWMutex + per-stream coordination)
+//
+// Example:
+//
+//	host := memoryhost.New()
+//	// transport wires this host into streaminghttp.New(...)
+//
+// For production multi-node deployments prefer a durable host like redishost.
+package memoryhost

--- a/sessions/redishost/doc.go
+++ b/sessions/redishost/doc.go
@@ -1,0 +1,26 @@
+// Package redishost implements sessions.SessionHost using Redis primitives
+// (Streams + simple keys) to support horizontally scalable MCP deployments.
+// It provides ordered per-session message streams, internal coordination
+// topics, metadata persistence with TTL / max lifetime enforcement, and small
+// per-session key/value storage.
+//
+// Design Notes
+//   - Session streams: XADD + XREAD consumer-group free polling; at-least-once
+//   - Internal events: topic streams started at "$" (only future events)
+//   - Metadata: JSON blob stored at key; MutateSession uses optimistic read/modify/write
+//   - Trimming: approximate MAXLEN to bound unbounded growth (configurable)
+//   - Auto-claim (future): plumbing present via WithClaimSettings for recovering orphaned deliveries
+//
+// Trade-offs
+//
+//	Pros: durability, multi-process coordination, simple operational model
+//	Cons: eventual trimming, at-least-once semantics require idempotent handlers
+//
+// Example:
+//
+//	host, _ := redishost.New("localhost:6379", redishost.WithKeyPrefix("mcp:"))
+//	defer host.Close()
+//
+// Use memoryhost for ephemeral development; use redishost where scale-out or
+// restart persistence is required.
+package redishost

--- a/stdio/doc.go
+++ b/stdio/doc.go
@@ -1,39 +1,27 @@
-// Package stdio provides a minimal MCP transport over stdin/stdout.
+// Package stdio implements a minimal single-connection MCP transport over
+// stdin/stdout. It is intended for embedding servers as subprocesses, local
+// development, and environments where spawning a child process and piping JSON
+// is simpler than running an HTTP server.
 //
-// Overview
-//   - Single-connection transport suitable for spawning an MCP server as a subprocess
-//   - Defaults to wiring to os.Stdin and os.Stdout
-//   - Optionally accepts custom io.Reader/io.Writer via the functional options pattern
-//   - Uses the current OS user as the authenticated principal by default
+// Characteristics
 //
-// The stdio transport is intentionally lightweight: it avoids HTTP, sessions hosts,
-// and authorization discovery/metadata. It is ideal for local development and for
-// servers embedded inside other processes that want to speak MCP over pipes.
+//	Connection model : 1 process <-> 1 client
+//	Auth             : OS user (lightweight implicit principal)
+//	Sessions         : Ephemeral; no host abstraction (memory only)
+//	Transport        : Line / stream oriented JSON-RPC
 //
-// Example
+// Options allow supplying alternate io.Reader / io.Writer or a custom logger.
 //
-//		package main
+// Example:
 //
-//		import (
-//		    "context"
-//		    "log"
+//	srv := mcpservice.NewServer(
+//	    mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-stdio-server", Version: "0.1.0"}),
+//	    // mcpservice.WithToolsCapability(...), etc.
+//	)
+//	h := stdio.NewHandler(srv)
+//	if err := h.Serve(context.Background()); err != nil { log.Fatal(err) }
 //
-//		    "github.com/ggoodman/mcp-server-go/mcp"
-//		    "github.com/ggoodman/mcp-server-go/mcpservice"
-//		    "github.com/ggoodman/mcp-server-go/stdio"
-//		)
-//
-//		func main() {
-//		    // Describe your server capabilities as usual.
-//	   server := mcpservice.NewServer(
-//	       mcpservice.WithServerInfo(mcp.ImplementationInfo{Name: "my-stdio-server", Version: "0.1.0"}),
-//	       // mcpservice.WithToolsCapability(...), mcpservice.WithResourcesCapability(...), etc.
-//	   )
-//
-//		    h := stdio.NewHandler(server)
-//
-//		    if err := h.Serve(context.Background()); err != nil {
-//		        log.Fatal(err)
-//		    }
-//		}
+// For multi-session, horizontally scalable deployments prefer the streaming
+// HTTP transport which integrates with session hosts, authentication and
+// subscription fan-out.
 package stdio

--- a/streaminghttp/doc.go
+++ b/streaminghttp/doc.go
@@ -1,0 +1,57 @@
+// Package streaminghttp implements the MCP streaming HTTP transport. It mounts
+// as a standard net/http handler and provides ordered bidirectional JSON-RPC
+// over long-lived streaming responses (Server-Sent Events style) plus normal
+// request/response for RPC calls initiated by the client.
+//
+// Responsibilities
+//   - Session creation & validation (via sessions.SessionHost)
+//   - Authentication (pluggable auth.Authenticator; OIDC or manual config)
+//   - Capability discovery (invokes mcpservice.ServerCapabilities getters)
+//   - Ordered outbound event fan-out (progress, listChanged, resource updates)
+//   - Subscription bridging (resources/updated per session + URI)
+//
+// Construction
+//
+//	h, err := streaminghttp.New(
+//	    ctx,
+//	    "https://api.example/mcp", // public endpoint base
+//	    host,                       // sessions.SessionHost implementation
+//	    server,                     // mcpservice.ServerCapabilities
+//	    authenticator,              // auth.Authenticator
+//	    streaminghttp.WithAuthorizationServerDiscovery("https://issuer.example"),
+//	)
+//
+// Exactly one auth mode must be supplied: discovery or manual OIDC metadata.
+//
+// # Session Context Lifetimes
+//
+// The handler derives a parent context per session (decoupled from individual
+// HTTP request cancellation) allowing long-lived subscription forwarders to run
+// while individual RPC requests time out or disconnect. Cancellation occurs
+// on explicit session termination or invalidation.
+//
+// # Scaling
+//
+// Horizontal scale relies on a shared SessionHost. Each node handles any mix
+// of requests; ordering for a given session is preserved by the host's stream
+// semantics, not sticky routing.
+//
+// Protected Resource Metadata (PRM)
+//
+// When OIDC discovery or manual metadata is configured, the handler exposes a
+// .well-known/protected-resource-metadata endpoint advertising issuer, jwks_uri
+// and supported authorization parameters, enabling clients to bootstrap without
+// out-of-band configuration.
+//
+// # Error Handling
+//
+// Transport-level errors map to HTTP status codes; MCP-level errors are
+// serialized as JSON-RPC error responses. Authentication failures surface a
+// WWW-Authenticate challenge per the authorization spec.
+//
+// Example (mount in net/http):
+//
+//	mux := http.NewServeMux()
+//	mux.Handle("/mcp/", h) // route prefix
+//	http.ListenAndServe(":8080", mux)
+package streaminghttp


### PR DESCRIPTION
- Introduced `auth` package with documentation on authentication primitives and JWT verification.
- Updated `elicitation` package documentation to clarify schema construction and decoding processes.
- Added `mcp` package documentation detailing protocol data types and constants.
- Created `sampling` package documentation for constructing sampling requests with ergonomic helpers.
- Enhanced `mcpservice` package documentation to explain capability interfaces and implementation strategies.
- Added `sessions` package documentation outlining session abstraction and capabilities.
- Introduced `memoryhost` and `redishost` packages with documentation for in-memory and Redis-based session hosts.
- Updated `stdio` package documentation to clarify its role as a minimal transport.
- Added `streaminghttp` package documentation for the MCP streaming HTTP transport and its responsibilities.