### PR TITLE
Fix Redis connection string format in New function and tests

### DIFF
--- a/sessions/redishost/redis.go
+++ b/sessions/redishost/redis.go
@@ -68,10 +68,11 @@ func WithClaimSettings(minIdle, interval time.Duration) Option {
 // New constructs a Host connecting to the provided Redis address (e.g. "localhost:6379").
 // Options can configure behavior such as key prefix. The connection is verified via PING.
 func New(redisAddr string, opts ...Option) (*Host, error) {
-	if redisAddr == "" {
-		redisAddr = "localhost:6379"
+	options, err := redis.ParseURL(redisAddr)
+	if err != nil {
+		return nil, fmt.Errorf("redis parse url: %w", err)
 	}
-	cl := redis.NewClient(&redis.Options{Addr: redisAddr})
+	cl := redis.NewClient(options)
 	if err := cl.Ping(context.Background()).Err(); err != nil {
 		return nil, fmt.Errorf("redis ping: %w", err)
 	}

--- a/sessions/redishost/redis_test.go
+++ b/sessions/redishost/redis_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRedisSessionHost(t *testing.T) {
 	// Quick availability check to allow graceful skip in environments without Redis
-	h, err := New("localhost:6379")
+	h, err := New("redis://localhost:6379")
 	if err != nil {
 		t.Skipf("skipping redis session host tests: %v", err)
 		return
@@ -21,7 +21,7 @@ func TestRedisSessionHost(t *testing.T) {
 	sessionhosttest.RunSessionHostTests(t, func(t *testing.T) sessions.SessionHost {
 		// Unique prefix per test run to avoid interference across runs
 		prefix := fmt.Sprintf("mcp:sessions:test:%d:", time.Now().UnixNano())
-		hh, err := New("localhost:6379", WithKeyPrefix(prefix))
+		hh, err := New("redis://localhost:6379", WithKeyPrefix(prefix))
 		if err != nil {
 			t.Fatalf("New: %v", err)
 		}


### PR DESCRIPTION
Update the Redis connection string format in the New function to use a URL format and adjust corresponding tests accordingly.