### PR TITLE
Implement session data storage methods

### DIFF
--- a/mcpservice/fs_resources_test.go
+++ b/mcpservice/fs_resources_test.go
@@ -22,6 +22,11 @@ func (s fakeSession) GetRootsCapability() (cap sessions.RootsCapability, ok bool
 func (s fakeSession) GetElicitationCapability() (cap sessions.ElicitationCapability, ok bool) {
 	return nil, false
 }
+func (s fakeSession) PutData(ctx context.Context, key string, value []byte) error { return nil }
+func (s fakeSession) GetData(ctx context.Context, key string) ([]byte, bool, error) {
+	return nil, false, nil
+}
+func (s fakeSession) DeleteData(ctx context.Context, key string) error { return nil }
 
 func writeFile(t *testing.T, dir, rel, content string) string {
 	t.Helper()

--- a/sessions/host.go
+++ b/sessions/host.go
@@ -60,7 +60,9 @@ type SessionHost interface {
 
 	// --- Per-session bounded KV storage ---
 	PutSessionData(ctx context.Context, sessionID, key string, value []byte) error
-	GetSessionData(ctx context.Context, sessionID, key string) ([]byte, error)
+	// GetSessionData returns (nil,false,nil) if the key does not exist, (v,true,nil)
+	// on success, and (nil,false,err) on backend / context error.
+	GetSessionData(ctx context.Context, sessionID, key string) (value []byte, found bool, err error)
 	DeleteSessionData(ctx context.Context, sessionID, key string) error
 }
 

--- a/sessions/memoryhost/memory.go
+++ b/sessions/memoryhost/memory.go
@@ -372,21 +372,21 @@ func (h *Host) PutSessionData(ctx context.Context, sessionID, key string, value 
 	return nil
 }
 
-func (h *Host) GetSessionData(ctx context.Context, sessionID, key string) ([]byte, error) {
+func (h *Host) GetSessionData(ctx context.Context, sessionID, key string) ([]byte, bool, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, false, ctx.Err()
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	m, ok := h.kv[sessionID]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, false, nil
 	}
 	v, ok := m[key]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, false, nil
 	}
-	return append([]byte(nil), v...), nil
+	return append([]byte(nil), v...), true, nil
 }
 
 func (h *Host) DeleteSessionData(ctx context.Context, sessionID, key string) error {

--- a/sessions/redishost/redis.go
+++ b/sessions/redishost/redis.go
@@ -375,15 +375,15 @@ func (h *Host) PutSessionData(ctx context.Context, sessionID, key string, value 
 	} // fallback default
 	return h.client.Set(ctx, rkey, value, ttl).Err()
 }
-func (h *Host) GetSessionData(ctx context.Context, sessionID, key string) ([]byte, error) {
+func (h *Host) GetSessionData(ctx context.Context, sessionID, key string) ([]byte, bool, error) {
 	v, err := h.client.Get(ctx, h.dataKey(sessionID, key)).Bytes()
 	if err != nil {
 		if err == redis.Nil {
-			return nil, errors.New("not found")
+			return nil, false, nil
 		}
-		return nil, err
+		return nil, false, err
 	}
-	return v, nil
+	return v, true, nil
 }
 func (h *Host) DeleteSessionData(ctx context.Context, sessionID, key string) error {
 	_, err := h.client.Del(ctx, h.dataKey(sessionID, key)).Result()

--- a/sessions/types.go
+++ b/sessions/types.go
@@ -19,6 +19,20 @@ type Session interface {
 	GetSamplingCapability() (cap SamplingCapability, ok bool)
 	GetRootsCapability() (cap RootsCapability, ok bool)
 	GetElicitationCapability() (cap ElicitationCapability, ok bool)
+
+	// PutData stores raw bytes value under key scoped to this session. The
+	// storage is best-effort bounded by host TTL / size constraints. Callers
+	// SHOULD keep values small (host-specific limits may apply). Context governs
+	// cancellation. Returns a backend error on failure.
+	PutData(ctx context.Context, key string, value []byte) error
+	// GetData retrieves raw bytes previously stored with PutData. It returns
+	// (nil, false, nil) ONLY when the key does not exist. It MUST NOT collapse
+	// backend/storage errors into (ok=false). Any transport, context cancellation
+	// or backend failure MUST surface via a non-nil err (caller should ignore ok
+	// when err != nil). An empty stored value returns ([]byte{}, true, nil).
+	GetData(ctx context.Context, key string) (value []byte, ok bool, err error)
+	// DeleteData removes the key if present. Missing keys are not an error.
+	DeleteData(ctx context.Context, key string) error
 }
 
 // MessageHandlerFunction handles ordered messages for a session stream.

--- a/tests/examples_lib_test.go
+++ b/tests/examples_lib_test.go
@@ -28,6 +28,11 @@ func (s fakeSession) GetRootsCapability() (sessions.RootsCapability, bool) { ret
 func (s fakeSession) GetElicitationCapability() (sessions.ElicitationCapability, bool) {
 	return nil, false
 }
+func (s fakeSession) PutData(ctx context.Context, key string, value []byte) error { return nil }
+func (s fakeSession) GetData(ctx context.Context, key string) ([]byte, bool, error) {
+	return nil, false, nil
+}
+func (s fakeSession) DeleteData(ctx context.Context, key string) error { return nil }
 
 func TestLib_EchoTool(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Introduce methods for storing, retrieving, and deleting session data within the SessionHandle and SessionHost interfaces. Update the SessionHost interface to reflect these changes and ensure proper handling of session data in tests.