### PR TITLE
Manual clean-up of some sloppy logging and wiring

### DIFF
--- a/internal/engine/elicitation_capability.go
+++ b/internal/engine/elicitation_capability.go
@@ -22,7 +22,6 @@ type elicitationCapability struct {
 	sessID              string
 	userID              string
 	requestScopedWriter MessageWriter
-	sessionScopedWriter MessageWriter
 }
 
 // Elicit implements sessions.ElicitationCapability.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
-	"github.com/ggoodman/mcp-server-go/internal/logctx"
 	"github.com/ggoodman/mcp-server-go/mcp"
 	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
@@ -280,9 +279,6 @@ func (e *Engine) HandleRequest(ctx context.Context, sessID, userID string, req *
 	if st := sess.State(); st != "" && st != sessions.SessionStateOpen {
 		return jsonrpc.NewErrorResponse(req.ID, jsonrpc.ErrorCodeInvalidRequest, "session not initialized", nil), nil
 	}
-
-	ctx = logctx.WithSessionID(ctx, sess.SessionID())
-	ctx = logctx.WithUserID(ctx, sess.userID)
 
 	switch req.Method {
 	case string(mcp.ToolsListMethod):

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/internal/logctx"
 	"github.com/ggoodman/mcp-server-go/mcp"
 	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
@@ -29,10 +30,9 @@ const (
 const internalSessionDeletedMethod = "internal/session/deleted"
 
 var (
-	ErrCancelled       = errors.New("operation cancelled")
-	ErrSessionNotFound = errors.New("session not found")
-	ErrInvalidUserID   = errors.New("invalid user id")
-	ErrInternal        = errors.New("internal error")
+	ErrCancelled     = errors.New("operation cancelled")
+	ErrInvalidUserID = errors.New("invalid user id")
+	ErrInternal      = errors.New("internal error")
 )
 
 // Engine is the core of an MCP server, coordinating sessions, message routing,
@@ -263,17 +263,7 @@ func (e *Engine) InitializeSession(ctx context.Context, userID string, req *mcp.
 	return sess, initRes, nil
 }
 
-func (e *Engine) HandleRequest(ctx context.Context, sessID, userID string, req *jsonrpc.Request, requestScopedWriter MessageWriter) (*jsonrpc.Response, error) {
-	sess, err := e.loadSession(ctx, sessID, userID, requestScopedWriter, NewMessageWriterFunc(
-		func(ctx context.Context, msg jsonrpc.Message) error {
-			_, err := e.host.PublishSession(ctx, sessID, msg)
-			return err
-		},
-	))
-	if err != nil {
-		return nil, err
-	}
-
+func (e *Engine) HandleRequest(ctx context.Context, sess *SessionHandle, req *jsonrpc.Request) (*jsonrpc.Response, error) {
 	// Require session to be open before serving requests (except initialize, which
 	// doesn't reach here).
 	if st := sess.State(); st != "" && st != sessions.SessionStateOpen {
@@ -799,18 +789,14 @@ func (e *Engine) handleResourcesRead(ctx context.Context, sess *SessionHandle, r
 // It verifies the session and republishes the notification to all instances without
 // actually handling the notification itself. The actual handling is done in the consumer loop
 // for these messages.
-func (e *Engine) HandleNotification(ctx context.Context, sessID, userID string, note *jsonrpc.Request) error {
-	_, err := e.loadSession(ctx, sessID, userID, nil, nil)
-	if err != nil {
-		return err
-	}
+func (e *Engine) HandleNotification(ctx context.Context, sess *SessionHandle, note *jsonrpc.Request) error {
 
-	// If the client signals initialized, open the session immediately on this
-	// instance to avoid local races, then fan out for other instances.
 	if note.Method == string(mcp.InitializedNotificationMethod) {
+		// If the client signals initialized, open the session immediately on this
+		// instance to avoid local races, then fan out for other instances.
 		now := time.Now().UTC()
-		if err := e.host.MutateSession(ctx, sessID, func(m *sessions.SessionMetadata) error {
-			if m == nil || m.Revoked || m.UserID != userID {
+		if err := e.host.MutateSession(ctx, sess.SessionID(), func(m *sessions.SessionMetadata) error {
+			if m == nil || m.Revoked || m.UserID != sess.UserID() {
 				return nil
 			}
 			// Idempotent: if already open, nothing to do.
@@ -827,52 +813,40 @@ func (e *Engine) HandleNotification(ctx context.Context, sessID, userID string, 
 			m.LastAccess = now
 			return nil
 		}); err != nil {
-			e.log.Error("engine.handle_notification.open.fail", slog.String("session_id", sessID), slog.String("user_id", userID), slog.String("err", err.Error()))
-			// Continue to publish fanout even if local mutation failed.
-		} else {
-			// Best-effort eager wiring; safe to call multiple times.
-			_ = e.eagerWireSession(ctx, sessID, userID)
+			e.log.Error("engine.handle_notification.open.fail", slog.String("err", err.Error()))
 		}
+
+		// Note: No need to dispatch this to peers; the mutation of the session state will
+		// be observed by peers when they next load the session.
+		return nil
 	}
 
-	if note.Method == string(mcp.CancelledNotificationMethod) {
-		var params mcp.CancelledNotification
-		if err := json.Unmarshal(note.Params, &params); err != nil {
-			e.log.Error("engine.handle_notification.cancel.decode", slog.String("session_id", sessID), slog.String("user_id", userID), slog.String("err", err.Error()))
-			return nil
-		}
-		if params.RequestID != nil && !params.RequestID.IsNil() {
-			ridStr := params.RequestID.String()
-			hadCancel := e.cancelInFlightRequest(ridStr, params.Reason)
-			e.log.Info("engine.handle_notification.cancel.dispatched", slog.String("session_id", sessID), slog.String("user_id", userID), slog.String("request_id", ridStr), slog.Bool("had_cancel", hadCancel))
-		}
-	}
-
-	// We got a notification from a transport. We don't directly handle notifications in the engine. Instead
-	// we dispatch it across the session host so that all instances can see it. The actual handling of
-	// notifications is done in the consumer loop for these messages.
+	// We got a notification from a client. We publish this to all peer instances on the session
+	// fanout topic. Each instance will then handle the notification in its consumer loop if
+	// it is relevant to that instance.
 	noteBytes, err := json.Marshal(note)
 	if err != nil {
-		e.log.Error("engine.handle_notification.err", slog.String("session_id", sessID), slog.String("user_id", userID), slog.String("err", err.Error()))
-		return err
+		e.log.Error("engine.handle_notification.err", slog.String("err", err.Error()))
+		return fmt.Errorf("failed to marshal notification: %w", err)
 	}
 	msg, err := json.Marshal(fanoutMessage{
-		SessionID: sessID,
-		UserID:    userID,
+		SessionID: sess.SessionID(),
+		UserID:    sess.UserID(),
 		Msg:       noteBytes,
 	})
 	if err != nil {
-		e.log.Error("engine.handle_notification.err", slog.String("session_id", sessID), slog.String("user_id", userID), slog.String("err", err.Error()))
-		return err
+		e.log.Error("engine.handle_notification.err", slog.String("err", err.Error()))
+		return fmt.Errorf("failed to marshal fanout message: %w", err)
 	}
 
 	if err := e.host.PublishEvent(ctx, sessionFanoutTopic, msg); err != nil {
-		e.log.Error("failed to publish notification", "error", err)
+		e.log.Error("engine.publish_event.err", slog.String("err", err.Error()))
+
 		return fmt.Errorf("failed to publish notification: %w", err)
 	}
 
 	// Trace successful dispatch
-	e.log.Info("engine.handle_notification.dispatch", slog.String("session_id", sessID), slog.String("user_id", userID), slog.String("method", note.Method))
+	e.log.Info("engine.handle_notification.ok")
 
 	return nil
 }
@@ -921,40 +895,30 @@ func (e *Engine) createSession(ctx context.Context, userID string, protocolVersi
 
 // eagerWireSession ensures the session has session-scoped writers wired so that
 // background capabilities can emit immediately after open.
-func (e *Engine) eagerWireSession(ctx context.Context, sessID, userID string) error {
-	// We only need a session-scoped writer that delivers to the per-session
-	// client-facing stream; requestScopedWriter can be nil here.
-	sess, err := e.loadSession(ctx, sessID, userID, nil, NewMessageWriterFunc(
-		func(ctx context.Context, msg jsonrpc.Message) error {
-			_, err := e.host.PublishSession(ctx, sessID, msg)
-			return err
-		},
-	))
-	if err != nil {
-		return err
-	}
+// It is idempotent per session.
+func (e *Engine) eagerWireSession(ctx context.Context, sess *SessionHandle) {
 	// Mark wiring intent (ensures wireMu is used at least for state guarding)
 	e.wireMu.Lock()
-	already := e.wired[sessID]
+	already := e.wired[sess.sessionID]
 	e.wireMu.Unlock()
+
 	if already {
-		return nil
+		return
 	}
-	return e.registerListChangedEmitters(ctx, sess)
+
+	e.registerListChangedEmitters(ctx, sess)
 }
 
 // registerListChangedEmitters wires capability change listeners to emit JSON-RPC
 // notifications on the per-session client stream. It is idempotent per session.
-//
-//lint:ignore U1000 used via eagerWireSession
-func (e *Engine) registerListChangedEmitters(ctx context.Context, sess *SessionHandle) error {
+func (e *Engine) registerListChangedEmitters(ctx context.Context, sess *SessionHandle) {
 	sid := sess.SessionID()
 	uid := sess.UserID()
 
 	e.wireMu.Lock()
 	if e.wired[sid] {
 		e.wireMu.Unlock()
-		return nil
+		return
 	}
 	e.wired[sid] = true
 	e.wireMu.Unlock()
@@ -1002,16 +966,14 @@ func (e *Engine) registerListChangedEmitters(ctx context.Context, sess *SessionH
 			})
 		}
 	}
-
-	return nil
 }
 
-// loadSession retrieves and validates session metadata, returning a handle.
+// LoadSession retrieves and validates session metadata, returning a handle.
 // It verifies the session belongs to the specified user and is not revoked.
 // It also performs a best-effort TTL touch. If a writers are provided, it sets
 // up capabilities according to the session's negotiated capabilities and
 // leverages the relevant writers for outbound messages.
-func (e *Engine) loadSession(ctx context.Context, sessID, userID string, requestScopedWriter MessageWriter, sessionScopedWriter MessageWriter) (*SessionHandle, error) {
+func (e *Engine) LoadSession(ctx context.Context, sessID, userID string, requestScopedWriter MessageWriter) (*SessionHandle, error) {
 	start := time.Now()
 	metaRec, err := e.host.GetSession(ctx, sessID)
 	if err != nil {
@@ -1020,7 +982,7 @@ func (e *Engine) loadSession(ctx context.Context, sessID, userID string, request
 	}
 	if metaRec.Revoked || metaRec.UserID == "" || metaRec.UserID != userID {
 		e.log.InfoContext(ctx, "engine.load_session.denied", slog.String("session_id", sessID), slog.String("user_id", userID))
-		return nil, ErrSessionNotFound
+		return nil, sessions.ErrSessionNotFound
 	}
 	// Best-effort sliding TTL touch.
 	_ = e.host.TouchSession(ctx, sessID)
@@ -1029,7 +991,7 @@ func (e *Engine) loadSession(ctx context.Context, sessID, userID string, request
 
 	opts := []SessionHandleOption{}
 
-	if requestScopedWriter != nil && sessionScopedWriter != nil {
+	if requestScopedWriter != nil {
 		if metaRec.Capabilities.Sampling {
 			opts = append(opts, WithSamplingCapability(&samplingCapabilty{
 				eng:                 e,
@@ -1037,7 +999,6 @@ func (e *Engine) loadSession(ctx context.Context, sessID, userID string, request
 				sessID:              sessID,
 				userID:              userID,
 				requestScopedWriter: requestScopedWriter,
-				sessionScopedWriter: sessionScopedWriter,
 			}))
 		}
 		if metaRec.Capabilities.Roots {
@@ -1047,7 +1008,6 @@ func (e *Engine) loadSession(ctx context.Context, sessID, userID string, request
 				sessID:              sessID,
 				userID:              userID,
 				requestScopedWriter: requestScopedWriter,
-				sessionScopedWriter: sessionScopedWriter,
 			}))
 		}
 		if metaRec.Capabilities.Elicitation {
@@ -1057,12 +1017,15 @@ func (e *Engine) loadSession(ctx context.Context, sessID, userID string, request
 				sessID:              sessID,
 				userID:              userID,
 				requestScopedWriter: requestScopedWriter,
-				sessionScopedWriter: sessionScopedWriter,
 			}))
 		}
 	}
 
-	return NewSessionHandle(e.host, metaRec, opts...), nil
+	sess := NewSessionHandle(e.host, metaRec, opts...)
+
+	e.eagerWireSession(ctx, sess)
+
+	return sess, nil
 }
 
 func (e *Engine) cancelInFlightRequest(reqID string, reason string) bool {
@@ -1098,48 +1061,46 @@ func (e *Engine) cancelInFlightRequest(reqID string, reason string) bool {
 func (e *Engine) handleSessionEvent(ctx context.Context, msg []byte) error {
 	var fanout fanoutMessage
 	if err := json.Unmarshal(msg, &fanout); err != nil {
-		e.log.Error("engine.handle_session_event.err", slog.String("err", err.Error()))
+		e.log.ErrorContext(ctx, "engine.handle_session_event.err", slog.String("err", err.Error()))
 		return nil // ignore malformed messages
 	}
 
-	// Trace event receipt
-	e.log.Info("engine.handle_session_event.recv", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID))
+	sess, err := e.LoadSession(ctx, fanout.SessionID, fanout.UserID, nil)
+	if err != nil {
+		ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+			SessionID: fanout.SessionID,
+			UserID:    fanout.UserID,
+		})
+
+		// Session not found or invalid; nothing to do.
+		e.log.InfoContext(ctx, "engine.handle_session_event.load_err", slog.String("err", err.Error()))
+		return nil
+	}
+
+	ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+		SessionID:       sess.SessionID(),
+		UserID:          sess.UserID(),
+		ProtocolVersion: sess.ProtocolVersion(),
+		State:           sess.State(),
+	})
 
 	var jsonMsg jsonrpc.AnyMessage
 	if err := json.Unmarshal(fanout.Msg, &jsonMsg); err != nil {
-		e.log.Error("engine.handle_session_event.err", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("err", err.Error()))
+		e.log.ErrorContext(ctx, "engine.handle_session_event.unmarshal_err", slog.String("err", err.Error()))
 		return nil // ignore malformed messages
 	}
+
+	ctx = logctx.WithRPCMessage(ctx, &logctx.RPCMessage{
+		Method: jsonMsg.Method,
+		ID:     jsonMsg.ID.String(),
+		Type:   jsonMsg.Type(),
+	})
+
+	e.log.InfoContext(ctx, "engine.handle_session_event.recv")
 
 	req := jsonMsg.AsRequest()
 	if req != nil {
 		switch req.Method {
-		case string(mcp.InitializedNotificationMethod):
-			now := time.Now().UTC()
-			// Flip session to open (idempotent) for cross-instance coordination.
-			if err := e.host.MutateSession(ctx, fanout.SessionID, func(m *sessions.SessionMetadata) error {
-				if m == nil || m.Revoked || m.UserID != fanout.UserID {
-					return nil
-				}
-				if m.State == sessions.SessionStateOpen {
-					return nil
-				}
-				m.State = sessions.SessionStateOpen
-				if m.OpenedAt.IsZero() {
-					m.OpenedAt = now
-				}
-				m.TTL = e.sessionTTL
-				m.UpdatedAt = now
-				m.LastAccess = now
-				return nil
-			}); err != nil {
-				e.log.Error("engine.handle_session_event.open.fail", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("err", err.Error()))
-				return nil
-			}
-			// Eager-wire emitters after open.
-			_ = e.eagerWireSession(ctx, fanout.SessionID, fanout.UserID)
-			e.log.Info("engine.handle_session_event.open", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID))
-			return nil
 		case internalSessionDeletedMethod:
 			// Teardown any local per-session subscriptions.
 			e.cancelAllSubscriptionsForSession(fanout.SessionID)
@@ -1147,23 +1108,23 @@ func (e *Engine) handleSessionEvent(ctx context.Context, msg []byte) error {
 		case string(mcp.CancelledNotificationMethod):
 			var params mcp.CancelledNotification
 			if err := json.Unmarshal(req.Params, &params); err != nil {
-				e.log.Error("engine.handle_session_event.err", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("err", err.Error()))
+				e.log.Error("engine.handle_session_event.err", slog.String("err", err.Error()))
 				return nil // ignore malformed messages
 			}
 
 			if params.RequestID != nil && !params.RequestID.IsNil() {
 				ridStr := params.RequestID.String()
 				// Trace cancellation delivery
-				e.log.Info("engine.handle_session_event.cancel", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("request_id", ridStr), slog.String("reason", params.Reason))
+				e.log.Info("engine.handle_session_event.cancel", slog.String("request_id", ridStr), slog.String("reason", params.Reason))
 
 				hadCancel := e.cancelInFlightRequest(ridStr, params.Reason)
-				e.log.Info("engine.handle_session_event.cancel.dispatched", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("request_id", ridStr), slog.Bool("had_cancel", hadCancel))
+				e.log.Info("engine.handle_session_event.cancel.dispatched", slog.String("request_id", ridStr), slog.Bool("had_cancel", hadCancel))
 			}
 			return nil
 		case string(mcp.ResourcesUnsubscribeMethod):
 			var params mcp.UnsubscribeRequest
 			if err := json.Unmarshal(req.Params, &params); err != nil {
-				e.log.Error("engine.handle_session_event.err", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("err", err.Error()))
+				e.log.Error("engine.handle_session_event.err", slog.String("err", err.Error()))
 				return nil
 			}
 			// Best-effort local cancel triggered by fanout message.
@@ -1190,7 +1151,7 @@ func (e *Engine) handleSessionEvent(ctx context.Context, msg []byte) error {
 		// Responses will typically satisfy a rendez-vous channel.
 		reqID := res.ID.String()
 		if reqID == "" {
-			e.log.Error("engine.handle_session_event.invalid", slog.String("session_id", fanout.SessionID), slog.String("user_id", fanout.UserID), slog.String("err", "empty request ID"))
+			e.log.Error("engine.handle_session_event.invalid", slog.String("err", "empty request ID"))
 			return nil // ignore malformed messages
 		}
 
@@ -1205,10 +1166,12 @@ func (e *Engine) handleSessionEvent(ctx context.Context, msg []byte) error {
 				// receiver not ready; drop as per at-least-once semantics
 			}
 			return nil
-		} else {
-			return nil
 		}
+
+		return nil
 	}
+
+	// Unknown message type; ignore.
 
 	return nil
 }
@@ -1249,38 +1212,24 @@ func (e *Engine) createRendezVous(reqID string) (<-chan []byte, func()) {
 // StreamSession validates the session ownership and subscribes the caller to the
 // per-session client-facing stream starting after lastEventID. It is a thin
 // wrapper over the host that centralizes auth/ownership checks in the Engine.
-func (e *Engine) StreamSession(ctx context.Context, sessID, userID, lastEventID string, handler sessions.MessageHandlerFunction) error {
-	meta, err := e.host.GetSession(ctx, sessID)
-	if err != nil || meta == nil || meta.Revoked || meta.UserID != userID {
-		return ErrSessionNotFound
-	}
-	// Best-effort TTL touch; ignore error
-	_ = e.host.TouchSession(ctx, sessID)
-	// Best-effort eager wiring so background emitters (e.g., listChanged) can fire
-	// as soon as a stream consumer attaches, even if notifications/initialized
-	// has not yet been sent by the client.
-	_ = e.eagerWireSession(ctx, sessID, userID)
-	return e.host.SubscribeSession(ctx, sessID, lastEventID, handler)
+func (e *Engine) StreamSession(ctx context.Context, sess *SessionHandle, lastEventID string, handler sessions.MessageHandlerFunction) error {
+	return e.host.SubscribeSession(ctx, sess.SessionID(), lastEventID, handler)
 }
 
 // HandleClientResponse validates the session ownership and forwards a client
 // JSON-RPC response into the Engine rendezvous via the inter-instance fanout.
 // This allows any node to satisfy the waiting request, regardless of where the
 // response was received.
-func (e *Engine) HandleClientResponse(ctx context.Context, sessID, userID string, res *jsonrpc.Response) error {
+func (e *Engine) HandleClientResponse(ctx context.Context, sess *SessionHandle, res *jsonrpc.Response) error {
 	if res == nil || res.ID == nil || res.ID.IsNil() {
 		return fmt.Errorf("invalid response: missing id")
-	}
-	meta, err := e.host.GetSession(ctx, sessID)
-	if err != nil || meta == nil || meta.Revoked || meta.UserID != userID {
-		return ErrSessionNotFound
 	}
 
 	payload, err := json.Marshal(res)
 	if err != nil {
 		return fmt.Errorf("marshal response: %w", err)
 	}
-	env, err := json.Marshal(fanoutMessage{SessionID: sessID, UserID: userID, Msg: payload})
+	env, err := json.Marshal(fanoutMessage{SessionID: sess.SessionID(), UserID: sess.UserID(), Msg: payload})
 	if err != nil {
 		return fmt.Errorf("marshal envelope: %w", err)
 	}
@@ -1290,44 +1239,35 @@ func (e *Engine) HandleClientResponse(ctx context.Context, sessID, userID string
 	return nil
 }
 
-// GetSessionProtocolVersion validates ownership and returns the negotiated
-// protocol version for the session. Returns ErrSessionNotFound if not owned or
-// missing.
-func (e *Engine) GetSessionProtocolVersion(ctx context.Context, sessID, userID string) (string, error) {
-	meta, err := e.host.GetSession(ctx, sessID)
-	if err != nil || meta == nil || meta.Revoked || meta.UserID != userID {
-		return "", ErrSessionNotFound
-	}
-	// Best-effort TTL touch
-	_ = e.host.TouchSession(ctx, sessID)
-	return meta.ProtocolVersion, nil
-}
-
 // DeleteSession validates ownership, returns the session protocol version for
 // convenience, and deletes the session from the host. Idempotent at the host
 // layer; returns ErrSessionNotFound if not owned or already gone.
-func (e *Engine) DeleteSession(ctx context.Context, sessID, userID string) (string, error) {
-	meta, err := e.host.GetSession(ctx, sessID)
-	if err != nil || meta == nil || meta.Revoked || meta.UserID != userID {
-		return "", ErrSessionNotFound
-	}
-	pv := meta.ProtocolVersion
+func (e *Engine) DeleteSession(ctx context.Context, sess *SessionHandle) error {
 	// Best-effort: cancel any local subscriptions for this session prior to deletion.
-	e.cancelAllSubscriptionsForSession(sessID)
+	e.cancelAllSubscriptionsForSession(sess.SessionID())
 
 	// Broadcast a fanout event so other instances can cancel their local subscriptions.
 	// This uses an internal method name understood only by the engine fanout handler.
 	note := &jsonrpc.Request{JSONRPCVersion: jsonrpc.ProtocolVersion, Method: internalSessionDeletedMethod}
 	bytes, _ := json.Marshal(note)
-	outer := fanoutMessage{SessionID: sessID, UserID: userID, Msg: bytes}
-	if payload, err := json.Marshal(outer); err == nil {
-		_ = e.host.PublishEvent(context.WithoutCancel(ctx), sessionFanoutTopic, payload)
+	outer := fanoutMessage{SessionID: sess.SessionID(), UserID: sess.UserID(), Msg: bytes}
+	payload, err := json.Marshal(outer)
+	if err != nil {
+		e.log.Error("engine.delete_session.marshal.err", slog.String("err", err.Error()))
+		return fmt.Errorf("error preparing fanout: %w", err)
 	}
 
-	if err := e.host.DeleteSession(ctx, sessID); err != nil {
-		return "", fmt.Errorf("delete session: %w", err)
+	if err := e.host.PublishEvent(context.WithoutCancel(ctx), sessionFanoutTopic, payload); err != nil {
+		e.log.Error("engine.delete_session.fanout.err", slog.String("err", err.Error()))
+		return fmt.Errorf("error publishing fanout: %w", err)
 	}
-	return pv, nil
+
+	if err := e.host.DeleteSession(ctx, sess.SessionID()); err != nil {
+		e.log.Error("engine.delete_session.err", slog.String("err", err.Error()))
+		return fmt.Errorf("error deleting session: %w", err)
+	}
+
+	return nil
 }
 
 // PublishToSession validates ownership and appends a JSON-RPC message to the
@@ -1335,7 +1275,7 @@ func (e *Engine) DeleteSession(ctx context.Context, sessID, userID string) (stri
 func (e *Engine) PublishToSession(ctx context.Context, sessID, userID string, msg jsonrpc.Message) (string, error) {
 	meta, err := e.host.GetSession(ctx, sessID)
 	if err != nil || meta == nil || meta.Revoked || meta.UserID != userID {
-		return "", ErrSessionNotFound
+		return "", sessions.ErrSessionNotFound
 	}
 	// Accept either already-encoded []byte or a struct implementing Message
 	var bytes []byte

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -943,7 +943,6 @@ func (e *Engine) registerListChangedEmitters(ctx context.Context, sess *SessionH
 	if resCap, ok, err := e.srv.GetResourcesCapability(bg, sess); err == nil && ok && resCap != nil {
 		if lc, hasLC, lErr := resCap.GetListChangedCapability(bg, sess); lErr == nil && hasLC && lc != nil {
 			_, _ = lc.Register(bg, sess, func(cbCtx context.Context, s sessions.Session, uri string) {
-				_ = uri // we emit generic listChanged per spec
 				publishNote(mcp.ResourcesListChangedNotificationMethod)
 			})
 		}

--- a/internal/engine/roots_capability.go
+++ b/internal/engine/roots_capability.go
@@ -20,7 +20,6 @@ type rootsCapability struct {
 	sessID              string
 	userID              string
 	requestScopedWriter MessageWriter
-	sessionScopedWriter MessageWriter
 }
 
 func (r *rootsCapability) ListRoots(ctx context.Context) (*mcp.ListRootsResult, error) {

--- a/internal/engine/sampling_capability.go
+++ b/internal/engine/sampling_capability.go
@@ -23,7 +23,6 @@ type samplingCapabilty struct {
 	sessID              string
 	userID              string
 	requestScopedWriter MessageWriter
-	sessionScopedWriter MessageWriter
 }
 
 // CreateMessage implements sessions.SamplingCapability.

--- a/internal/jsonrpc/requestid.go
+++ b/internal/jsonrpc/requestid.go
@@ -22,6 +22,9 @@ func NewRequestID(value interface{}) *RequestID {
 
 // String returns the string representation of the ID
 func (id *RequestID) String() string {
+	if id == nil {
+		return ""
+	}
 	if id.value == nil {
 		return ""
 	}

--- a/internal/logctx/logctx.go
+++ b/internal/logctx/logctx.go
@@ -10,7 +10,7 @@ type Handler struct {
 }
 
 func (h Handler) Handle(ctx context.Context, r slog.Record) error {
-	if rd, ok := ctx.Value(requestDataKey{}).(RequestData); ok {
+	if rd, ok := ctx.Value(requestDataKey{}).(*RequestData); ok {
 		r.AddAttrs(slog.Group("req",
 			slog.String("request_id", rd.RequestID),
 			slog.String("method", rd.Method),

--- a/internal/logctx/logctx.go
+++ b/internal/logctx/logctx.go
@@ -31,6 +31,14 @@ func (h Handler) Handle(ctx context.Context, r slog.Record) error {
 		))
 	}
 
+	if msg, ok := ctx.Value(rpcMsg{}).(*RPCMessage); ok {
+		r.AddAttrs(slog.Group("rpc",
+			slog.String("method", msg.Method),
+			slog.String("id", msg.ID),
+			slog.String("type", msg.Type),
+		))
+	}
+
 	return h.Handler.Handle(ctx, r)
 }
 

--- a/internal/logctx/logctx.go
+++ b/internal/logctx/logctx.go
@@ -11,11 +11,13 @@ type Handler struct {
 
 func (h Handler) Handle(ctx context.Context, r slog.Record) error {
 	if rd, ok := ctx.Value(requestDataKey{}).(RequestData); ok {
-		r.Add(slog.String("request_id", rd.RequestID))
-		r.Add(slog.String("method", rd.Method))
-		r.Add(slog.String("user_agent", rd.UserAgent))
-		r.Add(slog.String("remote_addr", rd.RemoteAddr))
-		r.Add(slog.String("path", rd.Path))
+		r.AddAttrs(slog.Group("req",
+			slog.String("request_id", rd.RequestID),
+			slog.String("method", rd.Method),
+			slog.String("user_agent", rd.UserAgent),
+			slog.String("remote_addr", rd.RemoteAddr),
+			slog.String("path", rd.Path),
+		))
 	}
 
 	return h.Handler.Handle(ctx, r)

--- a/sessions/host.go
+++ b/sessions/host.go
@@ -2,7 +2,16 @@ package sessions
 
 import (
 	"context"
+	"errors"
 )
+
+var (
+	ErrSessionNotFound = errors.New("session not found")
+)
+
+// MessageHandlerFunction handles ordered messages for a session stream.
+// If the handler returns an error, the subscription will terminate with that error.
+type MessageHandlerFunction func(ctx context.Context, msgID string, msg []byte) error
 
 // SessionHost defines the unified storage + messaging contract for sessions.
 // Implementations MUST be safe for concurrent use and suitable for horizontal

--- a/sessions/types.go
+++ b/sessions/types.go
@@ -35,10 +35,6 @@ type Session interface {
 	DeleteData(ctx context.Context, key string) error
 }
 
-// MessageHandlerFunction handles ordered messages for a session stream.
-// If the handler returns an error, the subscription will terminate with that error.
-type MessageHandlerFunction func(ctx context.Context, msgID string, msg []byte) error
-
 // ClientInfo identifies the client connecting to the server.
 type ClientInfo struct {
 	Name    string

--- a/stdio/handler.go
+++ b/stdio/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ggoodman/mcp-server-go/internal/engine"
 	"github.com/ggoodman/mcp-server-go/internal/jsonrpc"
+	"github.com/ggoodman/mcp-server-go/internal/logctx"
 	"github.com/ggoodman/mcp-server-go/mcp"
 	"github.com/ggoodman/mcp-server-go/mcpservice"
 	"github.com/ggoodman/mcp-server-go/sessions"
@@ -33,8 +34,7 @@ type Handler struct {
 	userID  string
 
 	initialized   bool
-	sessionOpen   bool
-	session       sessions.Session
+	sessID        string
 	sessionCancel context.CancelFunc
 }
 
@@ -54,13 +54,12 @@ func NewHandler(srv mcpservice.ServerCapabilities, opts ...Option) *Handler {
 }
 
 func (h *Handler) Serve(ctx context.Context) error {
-	logger := h.log.With(slog.String("component", "stdio.Handler"))
 	engineCtx, cancelEngine := context.WithCancel(ctx)
 	defer cancelEngine()
 
 	go func() {
 		if err := h.engine.Run(engineCtx); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Error("engine.run.fail", slog.String("err", err.Error()))
+			h.log.ErrorContext(ctx, "engine.run.fail", slog.String("err", err.Error()))
 		}
 	}()
 
@@ -90,49 +89,55 @@ func (h *Handler) Serve(ctx context.Context) error {
 			continue
 		}
 		if strings.HasPrefix(line, "[") {
-			h.writeError(logger, nil, jsonrpc.ErrorCodeInvalidRequest, "batch requests not supported", nil)
+			h.writeError(ctx, nil, jsonrpc.ErrorCodeInvalidRequest, "batch requests not supported", nil)
 			continue
 		}
 
 		var msg jsonrpc.AnyMessage
 		if err := json.Unmarshal([]byte(line), &msg); err != nil {
-			h.writeError(logger, nil, jsonrpc.ErrorCodeInvalidRequest, "invalid request", err.Error())
+			h.writeError(ctx, nil, jsonrpc.ErrorCodeInvalidRequest, "invalid request", err.Error())
 			continue
 		}
+
+		ctx = logctx.WithRPCMessage(ctx, &logctx.RPCMessage{
+			Method: msg.Method,
+			ID:     msg.ID.String(),
+			Type:   msg.Type(),
+		})
 
 		switch msg.Type() {
 		case "request":
 			req := msg.AsRequest()
 			if req == nil {
-				h.writeError(logger, msg.ID, jsonrpc.ErrorCodeInvalidRequest, "invalid request structure", nil)
+				h.writeError(ctx, msg.ID, jsonrpc.ErrorCodeInvalidRequest, "invalid request structure", nil)
 				continue
 			}
 			if req.Method == string(mcp.InitializeMethod) {
 				// Initialization is a one-time handshake; handle synchronously.
-				h.handleInitialize(engineCtx, logger, req)
+				h.handleInitialize(engineCtx, req)
 				continue
 			}
 
 			// Handle non-initialize requests concurrently so we can continue
 			// reading stdin for cancellations and client responses.
 			reqCopy := *req
-			go h.handleRequest(engineCtx, logger, &reqCopy)
+			go h.handleRequest(engineCtx, &reqCopy)
 		case "notification":
 			req := msg.AsRequest()
 			if req == nil {
-				logger.Warn("notification.malformed")
+				h.log.WarnContext(ctx, "notification.malformed")
 				continue
 			}
-			h.handleNotification(engineCtx, logger, req)
+			h.handleNotification(engineCtx, req)
 		case "response":
 			res := msg.AsResponse()
 			if res == nil {
-				logger.Warn("response.malformed")
+				h.log.WarnContext(ctx, "response.malformed")
 				continue
 			}
-			h.handleClientResponse(engineCtx, logger, res)
+			h.handleClientResponse(engineCtx, res)
 		default:
-			h.writeError(logger, msg.ID, jsonrpc.ErrorCodeInvalidRequest, "unknown message type", nil)
+			h.writeError(ctx, msg.ID, jsonrpc.ErrorCodeInvalidRequest, "unknown message type", nil)
 		}
 	}
 }
@@ -154,53 +159,56 @@ func (h *Handler) startSessionPump(ctx context.Context, sessionID string) {
 			return h.writeMessageBytes(msg)
 		})
 		if err != nil && !errors.Is(err, context.Canceled) {
-			h.log.Error("session.stream.fail", slog.String("session_id", sessionID), slog.String("err", err.Error()))
+			h.log.ErrorContext(ctx, "session.stream.fail", slog.String("session_id", sessionID), slog.String("err", err.Error()))
 		}
 	}()
 }
 
-func (h *Handler) handleInitialize(ctx context.Context, logger *slog.Logger, req *jsonrpc.Request) {
+func (h *Handler) handleInitialize(ctx context.Context, req *jsonrpc.Request) {
 	if h.initialized {
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInvalidRequest, "session already initialized", nil)
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInvalidRequest, "session already initialized", nil)
 		return
 	}
 
 	var initReq mcp.InitializeRequest
 	if err := json.Unmarshal(req.Params, &initReq); err != nil {
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid params", err.Error())
+		h.log.ErrorContext(ctx, "initialize.unmarshal.fail", slog.String("err", err.Error()))
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInvalidParams, "invalid params", err.Error())
 		return
 	}
 
 	sess, initRes, err := h.engine.InitializeSession(ctx, h.userID, &initReq)
 	if err != nil {
-		logger.Error("initialize.fail", slog.String("err", err.Error()))
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
+		h.log.ErrorContext(ctx, "initialize.session.fail", slog.String("err", err.Error()))
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
 		return
 	}
 
-	h.session = sess
+	ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+		SessionID: sess.SessionID(),
+		UserID:    sess.UserID(),
+		State:     sess.State(),
+	})
+
+	h.sessID = sess.SessionID()
 	h.initialized = true
 	// Do not start the session pump yet; wait for notifications/initialized.
 
 	resp, err := jsonrpc.NewResultResponse(req.ID, initRes)
 	if err != nil {
-		logger.Error("initialize.encode.fail", slog.String("err", err.Error()))
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
+		h.log.ErrorContext(ctx, "initialize.encode.fail", slog.String("err", err.Error()))
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
 		return
 	}
 
 	if err := h.writeJSON(resp); err != nil {
-		logger.Error("initialize.write.fail", slog.String("err", err.Error()))
+		h.log.ErrorContext(ctx, "initialize.write.fail", slog.String("err", err.Error()))
 	}
 }
 
-func (h *Handler) handleRequest(ctx context.Context, logger *slog.Logger, req *jsonrpc.Request) {
-	if !h.initialized || h.session == nil {
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInvalidRequest, "session not initialized", nil)
-		return
-	}
-	if !h.sessionOpen {
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInvalidRequest, "session not initialized", nil)
+func (h *Handler) handleRequest(ctx context.Context, req *jsonrpc.Request) {
+	if !h.initialized || h.sessID == "" {
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInvalidRequest, "session not initialized", nil)
 		return
 	}
 
@@ -215,10 +223,28 @@ func (h *Handler) handleRequest(ctx context.Context, logger *slog.Logger, req *j
 		return h.writeMessageBytes(msg)
 	})
 
-	res, err := h.engine.HandleRequest(reqCtx, h.session.SessionID(), h.session.UserID(), req, writer)
+	sess, err := h.engine.LoadSession(reqCtx, h.sessID, h.userID, writer)
 	if err != nil {
-		logger.Error("handle.request.fail", slog.String("method", req.Method), slog.String("err", err.Error()))
-		h.writeError(logger, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
+		ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+			SessionID: h.sessID,
+			UserID:    h.userID,
+		})
+
+		h.log.ErrorContext(ctx, "load.session.fail", slog.String("err", err.Error()))
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
+		return
+	}
+
+	ctx = logctx.WithSessionData(reqCtx, &logctx.SessionData{
+		SessionID: sess.SessionID(),
+		UserID:    sess.UserID(),
+		State:     sess.State(),
+	})
+
+	res, err := h.engine.HandleRequest(reqCtx, sess, req)
+	if err != nil {
+		h.log.ErrorContext(ctx, "handle.request.fail", slog.String("method", req.Method), slog.String("err", err.Error()))
+		h.writeError(ctx, req.ID, jsonrpc.ErrorCodeInternalError, "internal error", nil)
 		return
 	}
 
@@ -227,41 +253,58 @@ func (h *Handler) handleRequest(ctx context.Context, logger *slog.Logger, req *j
 	}
 
 	if err := h.writeJSON(res); err != nil {
-		logger.Error("response.write.fail", slog.String("err", err.Error()))
+		h.log.ErrorContext(ctx, "response.write.fail", slog.String("err", err.Error()))
 	}
 }
 
-func (h *Handler) handleNotification(ctx context.Context, logger *slog.Logger, note *jsonrpc.Request) {
-	if !h.initialized || h.session == nil {
-		logger.Warn("notification.before_initialize", slog.String("method", note.Method))
+func (h *Handler) handleNotification(ctx context.Context, note *jsonrpc.Request) {
+	if !h.initialized || h.sessID == "" {
+		h.log.WarnContext(ctx, "notification.before_initialize")
 		return
 	}
 
-	if err := h.engine.HandleNotification(ctx, h.session.SessionID(), h.session.UserID(), note); err != nil {
-		logger.Error("notification.handle.fail", slog.String("method", note.Method), slog.String("err", err.Error()))
+	sess, err := h.engine.LoadSession(ctx, h.sessID, h.userID, nil)
+	if err != nil {
+		h.log.ErrorContext(ctx, "notification.load_session.fail", slog.String("err", err.Error()))
 		return
 	}
 
-	if note.Method == string(mcp.InitializedNotificationMethod) && !h.sessionOpen {
+	ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+		SessionID: sess.SessionID(),
+		UserID:    sess.UserID(),
+		State:     sess.State(),
+	})
+
+	if err := h.engine.HandleNotification(ctx, sess, note); err != nil {
+		h.log.ErrorContext(ctx, "notification.handle.fail", slog.String("method", note.Method), slog.String("err", err.Error()))
+		return
+	}
+
+	if note.Method == string(mcp.InitializedNotificationMethod) {
 		// Mark session open locally and start pump; engine will flip state via fanout.
-		h.sessionOpen = true
-		h.startSessionPump(ctx, h.session.SessionID())
+		h.startSessionPump(ctx, sess.SessionID())
 	}
 }
 
-func (h *Handler) handleClientResponse(ctx context.Context, logger *slog.Logger, res *jsonrpc.Response) {
-	if !h.initialized || h.session == nil {
-		logger.Warn("response.before_initialize")
+func (h *Handler) handleClientResponse(ctx context.Context, res *jsonrpc.Response) {
+	if !h.initialized || h.sessID == "" {
+		h.log.WarnContext(ctx, "response.before_initialize")
 		return
 	}
 	if res.ID == nil || res.ID.IsNil() {
-		logger.Warn("response.missing_id")
+		h.log.WarnContext(ctx, "response.missing_id")
 		return
 	}
 
 	payload, err := json.Marshal(res)
 	if err != nil {
-		logger.Error("response.marshal.fail", slog.String("err", err.Error()))
+		h.log.ErrorContext(ctx, "response.marshal.fail", slog.String("err", err.Error()))
+		return
+	}
+
+	sess, err := h.engine.LoadSession(ctx, h.sessID, h.userID, nil)
+	if err != nil {
+		h.log.ErrorContext(ctx, "response.load_session.fail", slog.String("err", err.Error()))
 		return
 	}
 
@@ -270,17 +313,17 @@ func (h *Handler) handleClientResponse(ctx context.Context, logger *slog.Logger,
 		UserID    string `json:"user_id"`
 		Msg       []byte `json:"msg"`
 	}{
-		SessionID: h.session.SessionID(),
-		UserID:    h.session.UserID(),
+		SessionID: sess.SessionID(),
+		UserID:    sess.UserID(),
 		Msg:       payload,
 	})
 	if err != nil {
-		logger.Error("response.envelope.fail", slog.String("err", err.Error()))
+		h.log.ErrorContext(ctx, "response.envelope.fail", slog.String("err", err.Error()))
 		return
 	}
 
 	if err := h.host.PublishEvent(ctx, sessionFanoutTopic, envelope); err != nil && !errors.Is(err, context.Canceled) {
-		logger.Error("response.publish.fail", slog.String("err", err.Error()))
+		h.log.ErrorContext(ctx, "response.publish.fail", slog.String("err", err.Error()))
 	}
 }
 
@@ -307,10 +350,10 @@ func (h *Handler) writeJSON(v any) error {
 	return h.writeMessageBytes(b)
 }
 
-func (h *Handler) writeError(logger *slog.Logger, id *jsonrpc.RequestID, code jsonrpc.ErrorCode, msg string, data any) {
+func (h *Handler) writeError(ctx context.Context, id *jsonrpc.RequestID, code jsonrpc.ErrorCode, msg string, data any) {
 	resp := jsonrpc.NewErrorResponse(id, code, msg, data)
 	if err := h.writeJSON(resp); err != nil {
-		logger.Error("write error", slog.String("err", err.Error()))
+		h.log.ErrorContext(ctx, "write.error.fail", slog.String("err", err.Error()))
 	}
 }
 

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -428,8 +428,7 @@ func (h *StreamingHTTPHandler) handleDeleteMCP(w http.ResponseWriter, r *http.Re
 // MCP messages to the server and to establish a session.
 func (h *StreamingHTTPHandler) handlePostMCP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
-	ctx := logctx.WithRequestData(r.Context(), &logctx.RequestData{})
-	h.log.InfoContext(ctx, "http.post.start")
+	ctx := r.Context()
 
 	ctype, err := contenttype.GetMediaType(r)
 	if err != nil || !ctype.Matches(jsonMediaType) {
@@ -501,7 +500,12 @@ func (h *StreamingHTTPHandler) handlePostMCP(w http.ResponseWriter, r *http.Requ
 			return
 		}
 
-		ctx = logctx.WithSessionData(ctx, &logctx.SessionData{SessionID: sess.SessionID(), UserID: userInfo.UserID()})
+		ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+			SessionID:       sess.SessionID(),
+			UserID:          userInfo.UserID(),
+			ProtocolVersion: sess.ProtocolVersion(),
+			State:           sess.State(),
+		})
 
 		resp, err := jsonrpc.NewResultResponse(req.ID, initRes)
 		if err != nil {

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -345,14 +345,13 @@ func pathOnly(u *url.URL) string {
 }
 
 func (h *StreamingHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	r = r.WithContext(logctx.WithRequestData(r.Context(), &logctx.RequestData{
+	h.mux.ServeHTTP(w, r.WithContext(logctx.WithRequestData(r.Context(), &logctx.RequestData{
 		RequestID:  uuid.NewString(),
 		Method:     r.Method,
 		UserAgent:  r.UserAgent(),
 		RemoteAddr: r.RemoteAddr,
 		Path:       r.URL.Path,
-	}))
-	h.mux.ServeHTTP(w, r)
+	})))
 }
 
 // handleDeleteMCP handles the DELETE /mcp endpoint, which terminates an existing


### PR DESCRIPTION
Improve logging clarity and fix type assertions to use pointers. Remove unnecessary session writer fields and enhance error handling for session not found scenarios.