### PR TITLE
Fix logging context and serialize SSE messages

### DIFF
--- a/internal/engine/elicitation_capability.go
+++ b/internal/engine/elicitation_capability.go
@@ -50,7 +50,7 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 				return sessions.ElicitActionCancel, bindErr
 			}
 		} else {
-			c.log.ErrorContext(ctx, "elicitation.subject.invalid", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
+			c.log.ErrorContext(ctx, "elicitation.subject.invalid")
 			return sessions.ElicitActionCancel, sessions.ErrInvalidElicitSubject
 		}
 	}
@@ -110,7 +110,7 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 	select {
 	case msg, ok := <-rdvCh:
 		if !ok {
-			c.log.ErrorContext(ctx, "elicitation.create.cancelled", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
+			c.log.ErrorContext(ctx, "elicitation.create.cancelled")
 			return sessions.ElicitActionCancel, ErrCancelled
 		}
 
@@ -165,7 +165,7 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 
 		return action, nil
 	case <-ctx.Done():
-		c.log.ErrorContext(ctx, "elicitation.create.ctx.done", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
+		c.log.ErrorContext(ctx, "elicitation.create.ctx.done")
 		return sessions.ElicitActionCancel, ctx.Err()
 	}
 }

--- a/internal/engine/elicitation_capability.go
+++ b/internal/engine/elicitation_capability.go
@@ -40,17 +40,17 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 				defer func() {
 					if r := recover(); r != nil {
 						bindErr = errors.New("elicitation: panic during schema reflection")
-						c.log.Error("elicitation.bind.panic", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.Any("recover", r))
+						c.log.ErrorContext(ctx, "elicitation.bind.panic", slog.Any("recover", r))
 					}
 				}()
 				decoder, bindErr = pubelicit.BindStruct(subject)
 			}()
 			if bindErr != nil {
-				c.log.Error("elicitation.bind.err", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", bindErr.Error()))
+				c.log.ErrorContext(ctx, "elicitation.bind.err", slog.String("err", bindErr.Error()))
 				return sessions.ElicitActionCancel, bindErr
 			}
 		} else {
-			c.log.Error("elicitation.subject.invalid", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
+			c.log.ErrorContext(ctx, "elicitation.subject.invalid", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
 			return sessions.ElicitActionCancel, sessions.ErrInvalidElicitSubject
 		}
 	}
@@ -58,7 +58,7 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 	// Obtain schema (cached or constructed lazily by implementation)
 	sch, err := decoder.Schema()
 	if err != nil {
-		c.log.Error("elicitation.schema.err", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+		c.log.ErrorContext(ctx, "elicitation.schema.err", slog.String("err", err.Error()))
 		return sessions.ElicitActionCancel, ErrInternal
 	}
 
@@ -75,17 +75,17 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 	// Marshal schema JSON once
 	jsonBytes, err := sch.MarshalJSON()
 	if err != nil {
-		c.log.Error("elicitation.schema.marshal.err", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+		c.log.ErrorContext(ctx, "elicitation.schema.marshal.err", slog.String("err", err.Error()))
 		return sessions.ElicitActionCancel, ErrInternal
 	}
 	var wireSchema mcp.ElicitationSchema
 	if err := json.Unmarshal(jsonBytes, &wireSchema); err != nil { // should not fail; defensive
-		c.log.Error("elicitation.schema.unmarshal.err", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+		c.log.ErrorContext(ctx, "elicitation.schema.unmarshal.err", slog.String("err", err.Error()))
 		return sessions.ElicitActionCancel, ErrInternal
 	}
 	params, err := json.Marshal(mcp.ElicitRequest{Message: text, RequestedSchema: wireSchema})
 	if err != nil {
-		c.log.Error("elicitation.create.err", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+		c.log.ErrorContext(ctx, "elicitation.create.err", slog.String("err", err.Error()))
 		return sessions.ElicitActionCancel, ErrInternal
 	}
 
@@ -93,7 +93,7 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 
 	bytes, err := json.Marshal(clientReq)
 	if err != nil {
-		c.log.Error("elicitation.create.marshal.err", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+		c.log.ErrorContext(ctx, "elicitation.create.marshal.err", slog.String("err", err.Error()))
 		return sessions.ElicitActionCancel, ErrInternal
 	}
 
@@ -102,7 +102,7 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 	defer closeRdv()
 
 	if err := c.requestScopedWriter.WriteMessage(ctx, bytes); err != nil {
-		c.log.Error("elicitation.create.write.fail", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+		c.log.ErrorContext(ctx, "elicitation.create.write.fail", slog.String("err", err.Error()))
 		return sessions.ElicitActionCancel, ErrInternal
 	}
 
@@ -110,25 +110,25 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 	select {
 	case msg, ok := <-rdvCh:
 		if !ok {
-			c.log.Error("elicitation.create.cancelled", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
+			c.log.ErrorContext(ctx, "elicitation.create.cancelled", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
 			return sessions.ElicitActionCancel, ErrCancelled
 		}
 
 		// Decode JSON-RPC response envelope first
 		var resp jsonrpc.Response
 		if err := json.Unmarshal(msg, &resp); err != nil {
-			c.log.Error("elicitation.create.unmarshal_response.fail", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+			c.log.ErrorContext(ctx, "elicitation.create.unmarshal_response.fail", slog.String("err", err.Error()))
 			return sessions.ElicitActionCancel, ErrInternal
 		}
 		if resp.Error != nil {
-			c.log.Error("elicitation.create.error", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.Int("code", int(resp.Error.Code)), slog.String("message", resp.Error.Message))
+			c.log.ErrorContext(ctx, "elicitation.create.error", slog.Int("code", int(resp.Error.Code)), slog.String("message", resp.Error.Message))
 			return sessions.ElicitActionCancel, ErrInternal
 		}
 
 		// Unmarshal result payload
 		var er mcp.ElicitResult
 		if err := json.Unmarshal(resp.Result, &er); err != nil {
-			c.log.Error("elicitation.create.result.unmarshal.fail", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+			c.log.ErrorContext(ctx, "elicitation.create.result.unmarshal.fail", slog.String("err", err.Error()))
 			return sessions.ElicitActionCancel, ErrInternal
 		}
 
@@ -158,14 +158,14 @@ func (c *elicitationCapability) Elicit(ctx context.Context, text string, subject
 		// Only decode when accepted
 		if action == sessions.ElicitActionAccept {
 			if err := decoder.Decode(er.Content, nil); err != nil { // nil => use bound destination if implementation supports it
-				c.log.Error("elicitation.create.decode.fail", slog.String("session_id", c.sessID), slog.String("user_id", c.userID), slog.String("err", err.Error()))
+				c.log.ErrorContext(ctx, "elicitation.create.decode.fail", slog.String("err", err.Error()))
 				return sessions.ElicitActionCancel, ErrInternal
 			}
 		}
 
 		return action, nil
 	case <-ctx.Done():
-		c.log.Error("elicitation.create.ctx.done", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
+		c.log.ErrorContext(ctx, "elicitation.create.ctx.done", slog.String("session_id", c.sessID), slog.String("user_id", c.userID))
 		return sessions.ElicitActionCancel, ctx.Err()
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -812,10 +812,20 @@ func (e *Engine) HandleNotification(ctx context.Context, sess *SessionHandle, no
 			m.TTL = e.sessionTTL
 			m.UpdatedAt = now
 			m.LastAccess = now
+
+			ctx = logctx.WithSessionData(ctx, &logctx.SessionData{
+				SessionID:       sess.SessionID(),
+				UserID:          sess.UserID(),
+				ProtocolVersion: sess.ProtocolVersion(),
+				State:           m.State,
+			})
+
 			return nil
 		}); err != nil {
 			e.log.ErrorContext(ctx, "engine.handle_notification.open.fail", slog.String("err", err.Error()))
 		}
+
+		e.log.InfoContext(ctx, "engine.session.initialized")
 
 		// Note: No need to dispatch this to peers; the mutation of the session state will
 		// be observed by peers when they next load the session.

--- a/internal/logctx/logctx.go
+++ b/internal/logctx/logctx.go
@@ -39,6 +39,12 @@ func (h Handler) Handle(ctx context.Context, r slog.Record) error {
 		))
 	}
 
+	if td, ok := ctx.Value(toolCallDataKey{}).(*ToolCallData); ok {
+		r.AddAttrs(slog.Group("tool",
+			slog.String("name", td.ToolName),
+		))
+	}
+
 	return h.Handler.Handle(ctx, r)
 }
 
@@ -79,4 +85,14 @@ type SessionData struct {
 
 func WithSessionData(ctx context.Context, data *SessionData) context.Context {
 	return context.WithValue(ctx, sessionDataKey{}, data)
+}
+
+type toolCallDataKey struct{}
+
+type ToolCallData struct {
+	ToolName string
+}
+
+func WithToolCallData(ctx context.Context, data *ToolCallData) context.Context {
+	return context.WithValue(ctx, toolCallDataKey{}, data)
 }

--- a/stdio/handler.go
+++ b/stdio/handler.go
@@ -159,7 +159,7 @@ func (h *Handler) startSessionPump(ctx context.Context, sessionID string) {
 			return h.writeMessageBytes(msg)
 		})
 		if err != nil && !errors.Is(err, context.Canceled) {
-			h.log.ErrorContext(ctx, "session.stream.fail", slog.String("session_id", sessionID), slog.String("err", err.Error()))
+			h.log.ErrorContext(ctx, "session.stream.fail", slog.String("err", err.Error()))
 		}
 	}()
 }

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -264,7 +264,7 @@ func New(ctx context.Context, publicEndpoint string, host sessions.SessionHost, 
 	h.eng = engine.NewEngine(host, server, engine.WithLogger(h.log))
 	go func() {
 		if err := h.eng.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			h.log.Error("engine.run.fail", slog.String("err", err.Error()))
+			h.log.ErrorContext(ctx, "engine.run.fail", slog.String("err", err.Error()))
 		}
 	}()
 

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -701,8 +701,7 @@ func (h *StreamingHTTPHandler) handlePostMCP(w http.ResponseWriter, r *http.Requ
 		w.WriteHeader(http.StatusOK)
 		f.Flush()
 
-		ctx, cancel := context.WithCancel(r.Context())
-		defer cancel()
+		ctx := r.Context()
 
 		rid := req.ID.String()
 		ctx = mcpservice.WithProgressReporter(ctx, streamingProgressReporter{lw: wf, requestID: rid})

--- a/streaminghttp/handler.go
+++ b/streaminghttp/handler.go
@@ -67,10 +67,11 @@ func writeJSONError(w http.ResponseWriter, status int, msg string) {
 type Option func(*newConfig)
 
 type newConfig struct {
-	serverName     string
-	logger         *slog.Logger
-	securityConfig *auth.SecurityConfig
-	realm          string
+	serverName      string
+	logger          *slog.Logger
+	securityConfig  *auth.SecurityConfig
+	realm           string
+	verboseRequests bool
 }
 
 // WithServerName sets a human-readable server name surfaced in PRM.
@@ -97,6 +98,15 @@ func WithSecurityConfig(sc auth.SecurityConfig) Option {
 func WithRealm(realm string) Option {
 	return func(c *newConfig) { c.realm = strings.TrimSpace(realm) }
 }
+
+// WithVerboseRequestLogging enables leading/trailing edge logging for each HTTP
+// request that passes through the top-level StreamingHTTPHandler.ServeHTTP.
+// This is off by default to avoid log noise in high-throughput deployments.
+// When enabled, two info logs are emitted per request:
+//
+//	http.req.start  (immediately after context enrichment)
+//	http.req.end    (after downstream handler completes) with duration
+func WithVerboseRequestLogging() Option { return func(c *newConfig) { c.verboseRequests = true } }
 
 // buildBearerChallenge builds a standardized Bearer challenge header value.
 // Format:
@@ -159,11 +169,12 @@ type StreamingHTTPHandler struct {
 	authServerMetadata    wellknown.AuthServerMetadata
 	authServerMetadataURL *url.URL
 
-	auth        auth.Authenticator
-	mcp         mcpservice.ServerCapabilities
-	eng         *engine.Engine
-	sessionHost sessions.SessionHost
-	realm       string
+	auth            auth.Authenticator
+	mcp             mcpservice.ServerCapabilities
+	eng             *engine.Engine
+	sessionHost     sessions.SessionHost
+	realm           string
+	verboseRequests bool
 }
 
 type lockedSSEWriter struct {
@@ -259,7 +270,7 @@ func New(ctx context.Context, publicEndpoint string, host sessions.SessionHost, 
 
 	loggerWithContextHandler := slog.New(logctx.Handler{Handler: cfg.logger.Handler()})
 
-	h := &StreamingHTTPHandler{log: loggerWithContextHandler, serverURL: mcpURL, auth: authenticator, mcp: server, sessionHost: host, realm: cfg.realm}
+	h := &StreamingHTTPHandler{log: loggerWithContextHandler, serverURL: mcpURL, auth: authenticator, mcp: server, sessionHost: host, realm: cfg.realm, verboseRequests: cfg.verboseRequests}
 
 	h.eng = engine.NewEngine(host, server, engine.WithLogger(h.log))
 	go func() {
@@ -343,14 +354,78 @@ func pathOnly(u *url.URL) string {
 	return u.Path
 }
 
+// loggingResponseWriter wraps http.ResponseWriter to capture status code,
+// bytes written and content-type for end-of-request logging. It is only
+// allocated when verbose request logging is enabled to keep the normal path
+// allocation free.
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+	bytes       int
+	contentType string
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(code int) {
+	if !lrw.wroteHeader {
+		lrw.status = code
+		lrw.wroteHeader = true
+		if ct := lrw.Header().Get("Content-Type"); ct != "" {
+			lrw.contentType = ct
+		}
+	}
+	lrw.ResponseWriter.WriteHeader(code)
+}
+
+func (lrw *loggingResponseWriter) Write(p []byte) (int, error) {
+	if !lrw.wroteHeader {
+		// Implicit 200
+		lrw.WriteHeader(http.StatusOK)
+	}
+	n, err := lrw.ResponseWriter.Write(p)
+	lrw.bytes += n
+	if lrw.contentType == "" {
+		if ct := lrw.Header().Get("Content-Type"); ct != "" {
+			lrw.contentType = ct
+		}
+	}
+	return n, err
+}
+
 func (h *StreamingHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.mux.ServeHTTP(w, r.WithContext(logctx.WithRequestData(r.Context(), &logctx.RequestData{
+	ctx := logctx.WithRequestData(r.Context(), &logctx.RequestData{
 		RequestID:  uuid.NewString(),
 		Method:     r.Method,
 		UserAgent:  r.UserAgent(),
 		RemoteAddr: r.RemoteAddr,
 		Path:       r.URL.Path,
-	})))
+	})
+	r = r.WithContext(ctx)
+
+	if !h.verboseRequests {
+		h.mux.ServeHTTP(w, r)
+		return
+	}
+
+	start := time.Now()
+	h.log.InfoContext(ctx, "http.req.start")
+
+	lrw := &loggingResponseWriter{ResponseWriter: w}
+	h.mux.ServeHTTP(lrw, r)
+
+	// Default values if nothing written.
+	status := lrw.status
+	if status == 0 { // never wrote header
+		status = http.StatusOK
+	}
+	h.log.InfoContext(ctx, "http.req.end",
+		slog.Duration("dur", time.Since(start)),
+		slog.Group("resp",
+			slog.Int("status", status),
+			slog.String("content_type", lrw.contentType),
+			slog.Int("bytes", lrw.bytes),
+		),
+	)
 }
 
 // handleDeleteMCP handles the DELETE /mcp endpoint, which terminates an existing


### PR DESCRIPTION
Update logging to use context-aware functions for improved error tracking and utilize a locked SSE writer for serializing SSE messages.