### PR TITLE
Refactor static resources management in mcpservice

### DIFF
--- a/examples/resources_static/server.go
+++ b/examples/resources_static/server.go
@@ -1,24 +1,22 @@
 package resources_static
 
 import (
-	"github.com/ggoodman/mcp-server-go/mcp"
 	"github.com/ggoodman/mcp-server-go/mcpservice"
 )
 
 // New constructs a server with a static resources capability: two small text resources
 // and their contents. Useful for listing and reading examples.
 func New() mcpservice.ServerCapabilities {
-	res := []mcp.Resource{
-		{URI: "res://hello.txt", Name: "hello.txt", MimeType: "text/plain"},
-		{URI: "res://readme.md", Name: "readme.md", MimeType: "text/markdown"},
-	}
-	contents := map[string][]mcp.ResourceContents{
-		"res://hello.txt": {{URI: "res://hello.txt", MimeType: "text/plain", Text: "hello"}},
-		"res://readme.md": {{URI: "res://readme.md", MimeType: "text/markdown", Text: "# Readme\nThis is a test."}},
-	}
-
-	static := mcpservice.NewResourcesContainer(res, nil, contents)
-
+	static := mcpservice.NewResourcesContainer()
+	// Populate via upserts for clarity
+	static.UpsertResource(mcpservice.TextResource("res://hello.txt", "hello",
+		mcpservice.WithName("hello.txt"),
+		mcpservice.WithMimeType("text/plain"),
+	))
+	static.UpsertResource(mcpservice.TextResource("res://readme.md", "# Readme\nThis is a test.",
+		mcpservice.WithName("readme.md"),
+		mcpservice.WithMimeType("text/markdown"),
+	))
 	return mcpservice.NewServer(
 		mcpservice.WithServerInfo(mcpservice.StaticServerInfo("examples-resources-static", "0.1.0")),
 		mcpservice.WithResourcesCapability(static),

--- a/streaminghttp/handler_test.go
+++ b/streaminghttp/handler_test.go
@@ -468,7 +468,7 @@ func TestMultiInstance(t *testing.T) {
 		sharedHost := memoryhost.New()
 
 		// Shared static resources container across handler instances
-		sharedSR := mcpservice.NewResourcesContainer(nil, nil, nil)
+		sharedSR := mcpservice.NewResourcesContainer()
 
 		// Distinct server instances per handler: share the static resources container
 		mcpFactory := func() mcpservice.ServerCapabilities {
@@ -522,7 +522,7 @@ func TestMultiInstance(t *testing.T) {
 		defer respGet.Body.Close()
 
 		// Step 4/5: Trigger and wait (with retries) for resources list_changed
-		trigger := func() { sharedSR.ReplaceResources(context.Background(), sharedSR.SnapshotResources()) }
+		trigger := func() { sharedSR.ReplaceResources(sharedSR.SnapshotResources()) }
 		// Initial trigger before entering retry loop to preserve existing behavior
 		trigger()
 		waitForListChanged(t, t.Context(), eventsCh, trigger)

--- a/tests/resources_listchanged_e2e_test.go
+++ b/tests/resources_listchanged_e2e_test.go
@@ -31,11 +31,8 @@ func TestResources_ListChanged_E2E(t *testing.T) {
 	// emits list-changed notifications on mutations (add/remove/replace), and
 	// the resources capability advertises listChanged support when a container
 	// is used—no explicit ChangeNotifier wiring required.
-	static := mcpservice.NewResourcesContainer(
-		[]mcp.Resource{{URI: "res://a", Name: "a"}},
-		nil,
-		map[string][]mcp.ResourceContents{"res://a": {{URI: "res://a", Text: "A"}}},
-	)
+	static := mcpservice.NewResourcesContainer()
+	static.UpsertResource(mcpservice.TextResource("res://a", "A", mcpservice.WithName("a")))
 	srvCaps := mcpservice.NewServer(
 		mcpservice.WithResourcesCapability(static),
 	)
@@ -106,7 +103,7 @@ func TestResources_ListChanged_E2E(t *testing.T) {
 	// 3) Give the GET handler a brief moment to subscribe and register publishers, then trigger list-changed
 	time.Sleep(150 * time.Millisecond)
 	// Trigger list-changed by mutating the static set (auto-notifies)
-	_ = static.AddResource(ctx, mcp.Resource{URI: "res://b", Name: "b"})
+	static.AddResource(mcpservice.Resource{URI: "res://b", Name: "b"})
 
 	var getResp *http.Response
 	select {

--- a/tests/resources_subscribe_multinode_e2e_test.go
+++ b/tests/resources_subscribe_multinode_e2e_test.go
@@ -41,11 +41,8 @@ func TestResources_SubscribeUpdated_MultiNode_UnsubscribeFanout(t *testing.T) {
 	defer h.Close()
 
 	// Shared ResourcesContainer backing on handler A
-	static := mcpservice.NewResourcesContainer(
-		[]mcp.Resource{{URI: "res://x", Name: "x"}},
-		nil,
-		map[string][]mcp.ResourceContents{"res://x": {{URI: "res://x", Text: "v1"}}},
-	)
+	static := mcpservice.NewResourcesContainer()
+	static.UpsertResource(mcpservice.TextResource("res://x", "v1", mcpservice.WithName("x")))
 	srvCapsA := mcpservice.NewServer(
 		mcpservice.WithResourcesCapability(static),
 	)
@@ -194,7 +191,7 @@ func TestResources_SubscribeUpdated_MultiNode_UnsubscribeFanout(t *testing.T) {
 	}()
 
 	// Trigger update on A and expect resources/updated on B within a reasonable bound
-	static.ReplaceAllContents(ctx, map[string][]mcp.ResourceContents{"res://x": {{URI: "res://x", Text: "v2"}}})
+	static.UpsertResource(mcpservice.TextResource("res://x", "v2", mcpservice.WithName("x")))
 	{
 		timeout := time.NewTimer(2 * time.Second)
 		defer timeout.Stop()


### PR DESCRIPTION
### Resources container ergonomics (breaking improvement)

From a user’s point of view the old resources API felt like working “inside the protocol” instead of just declaring some files. You had to:
- Build wire-shaped structs (MCP resource/content blocks) instead of plain Go values.
- Pass `context.Context` into trivial in‑memory operations.
- Replace whole slices to make small edits.
- Learn (and care about) subscription mechanics you didn’t ask for.

The redesigned container is intentionally boring—in a good way.

#### What you do now

```go
rc := mcpservice.NewResourcesContainer()

rc.AddResource(mcpservice.TextResource(
  "res://welcome",
  "Welcome!",
  mcpservice.WithName("Welcome"),
  mcpservice.WithDescription("Landing copy"),
  mcpservice.WithMimeType("text/plain"),
))

// Change or create (metadata + variants) with one call.
rc.UpsertResource(mcpservice.ResourceWithVariants(
  "res://logo",
  []mcpservice.ContentVariant{
    mcpservice.BlobVariant(logoPNGBytes, "image/png"),
  },
  mcpservice.WithName("Logo"),
))

// Force clients to refresh lists (even if structurally identical).
rc.ReplaceResources(rc.SnapshotResources())
```

#### Key ergonomic wins

- Plain structs: `Resource`, `ContentVariant`—no premature MCP wire coupling.
- Obvious CRUD: `AddResource`, `UpsertResource`, `RemoveResource`, `ReplaceResources`.
- No contexts for synchronous, in‑memory ops.
- Helper constructors (`TextResource`, `BlobResource`, variants helpers) remove boilerplate.
- `UpsertResource` handles create vs update; only emits “updated” if variants actually changed.
- Always emits listChanged on `ReplaceResources`—gives you a cheap “poke” to invalidate client caches.
- Engine owns subscriptions now; you never juggle session IDs or goroutines.

#### Mental model now

“Declare resources, mutate them directly, and the system will push the right notifications.”  
No subscription plumbing, no slice surgery, no protocol leakage.

That’s the whole point: lower cognitive load, fewer ways to misuse it, zero ceremony for the 90% case.